### PR TITLE
Add getLandTransferTax function

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -316,6 +316,52 @@ capital gains tax baked into them. Summing all itemized deductions plus
 and $5k Capital Gains, excluding RAMQ getIncomeTax(80000, "Quebec", 2025, {
 rrsp: 10000, capitalGains: 5000, quebec: { ramq: false } });
 
+## getLandTransferTax
+
+Calculates the standard Land Transfer Tax (or equivalent registration fee) for a
+given city and property value based on 2026 tax frameworks.
+
+- **Rebate Limitations and Exclusions:** The `firstTimeOwner` parameter applies
+  structural, point-of-sale land transfer tax rebates assuming the buyer meets
+  all idealized programmatic criteria (e.g., absolute zero global ownership
+  history, Canadian citizenship/PR, and continuous provincial residency).
+- The following rebates and subsidies are INTENTIONALLY EXCLUDED from this
+  calculation:
+
+* **Nova Scotia:** The First-Time Home Buyers Rebate is excluded because it is
+  restricted exclusively to a refund on the provincial portion of the HST for
+  _newly built_ properties, not the 1.5% municipal Deed Transfer Tax calculated
+  here.
+* **Montreal (HPAP) & Quebec City (Programme Accès Famille):** Excluded because
+  they operate as localized financial grants or down payment assistance loans
+  requiring specific household compositions (e.g., dependents under 18) or
+  new-build environmental certifications, rather than structural tax base
+  reductions.
+* **Manitoba:** Excluded because the "Home Buyers' Amount" is a $1,500 general
+  income tax credit claimed on annual tax returns, not an upfront point-of-sale
+  deduction from the provincial land transfer tax.
+
+### Signature
+
+```typescript
+function getLandTransferTax(
+  city: City,
+  propertyValue: number,
+  firstTimeOwner?: boolean,
+): number;
+```
+
+### Parameters
+
+- **`city`**: The metropolitan market.
+- **`propertyValue`**: The fair market value or purchase price of the property.
+- **`firstTimeOwner`**: Indicates if the purchaser qualifies for strict FTHB
+  exemptions.
+
+### Returns
+
+The total calculated transaction friction cost in Canadian Dollars.
+
 ## getMortgagePenalty
 
 Calculates the mortgage prepayment penalty.

--- a/src/finance/getLandTransferTax.ts
+++ b/src/finance/getLandTransferTax.ts
@@ -1,4 +1,7 @@
-type City =
+/**
+ * Valid Canadian metropolitan markets for Land Transfer Tax calculations.
+ */
+export type City =
   | "Toronto"
   | "Montreal"
   | "Calgary"

--- a/src/finance/getLandTransferTax.ts
+++ b/src/finance/getLandTransferTax.ts
@@ -1,0 +1,275 @@
+type City =
+  | "Toronto"
+  | "Montreal"
+  | "Calgary"
+  | "Ottawa"
+  | "Edmonton"
+  | "Winnipeg"
+  | "Vancouver"
+  | "Hamilton"
+  | "Quebec"
+  | "Halifax"
+  | "London"
+  | "Saskatoon"
+  | "Kitchener-Waterloo"
+  | "Regina"
+  | "Victoria"
+  | "Barrie"
+  | "Guelph"
+  | "Kingston"
+  | "Fredericton"
+  | "Moncton"
+  | "Saint John (NB)"
+  | "Saint John's (NL)";
+
+interface TaxBracket {
+  limit: number;
+  rate: number;
+}
+
+/**
+ * Helper function to calculate progressive marginal taxes.
+ */
+function calculateMarginalTax(value: number, brackets: TaxBracket[]): number {
+  let tax = 0;
+  let previousLimit = 0;
+
+  for (const bracket of brackets) {
+    if (value > previousLimit) {
+      const taxableAmount = Math.min(value, bracket.limit) - previousLimit;
+      tax += taxableAmount * bracket.rate;
+      previousLimit = bracket.limit;
+    } else {
+      break;
+    }
+  }
+
+  return tax;
+}
+
+/**
+ * Calculates the standard Land Transfer Tax (or equivalent registration fee)
+ * for a given city and property value based on 2026 tax frameworks.
+ * * **Rebate Limitations and Exclusions:**
+ * The `firstTimeOwner` parameter applies structural, point-of-sale land transfer tax
+ * rebates assuming the buyer meets all idealized programmatic criteria (e.g., absolute
+ * zero global ownership history, Canadian citizenship/PR, and continuous provincial residency).
+ * * The following rebates and subsidies are INTENTIONALLY EXCLUDED from this calculation:
+ * - **Nova Scotia:** The First-Time Home Buyers Rebate is excluded because it is restricted
+ * exclusively to a refund on the provincial portion of the HST for *newly built* properties,
+ * not the 1.5% municipal Deed Transfer Tax calculated here.
+ * - **Montreal (HPAP) & Quebec City (Programme Accès Famille):** Excluded because they operate
+ * as localized financial grants or down payment assistance loans requiring specific household
+ * compositions (e.g., dependents under 18) or new-build environmental certifications, rather
+ * than structural tax base reductions.
+ * - **Manitoba:** Excluded because the "Home Buyers' Amount" is a $1,500 general income tax
+ * credit claimed on annual tax returns, not an upfront point-of-sale deduction from the
+ * provincial land transfer tax.
+ * @param city - The metropolitan market.
+ * @param propertyValue - The fair market value or purchase price of the property.
+ * @param firstTimeOwner - Indicates if the purchaser qualifies for strict FTHB exemptions.
+ * @returns The total calculated transaction friction cost in Canadian Dollars.
+ */
+export default function getLandTransferTax(
+  city: City,
+  propertyValue: number,
+  firstTimeOwner: boolean = false,
+): number {
+  // 1. Ontario Provincial Brackets
+  // Tax Source: https://www.ontario.ca/document/land-transfer-tax/calculating-land-transfer-tax
+  const ontarioProvincialBrackets: TaxBracket[] = [
+    { limit: 55000, rate: 0.005 },
+    { limit: 250000, rate: 0.010 },
+    { limit: 400000, rate: 0.015 },
+    { limit: 2000000, rate: 0.020 },
+    { limit: Infinity, rate: 0.025 },
+  ];
+
+  const ontarioSecondaryCities = [
+    "Ottawa",
+    "Hamilton",
+    "London",
+    "Kitchener-Waterloo",
+    "Barrie",
+    "Guelph",
+    "Kingston",
+  ];
+
+  if (ontarioSecondaryCities.includes(city)) {
+    let tax = calculateMarginalTax(propertyValue, ontarioProvincialBrackets);
+    if (firstTimeOwner) {
+      // FTHB Source: https://www.ontario.ca/document/land-transfer-tax/land-transfer-tax-refunds-first-time-homebuyers
+      const rebate = Math.min(tax, 4000);
+      tax -= rebate;
+    }
+    return tax;
+  }
+
+  // 2. Toronto (Dual Taxation)
+  // Tax Source: https://www.toronto.ca/services-payments/property-taxes-utilities/municipal-land-transfer-tax-mltt/municipal-land-transfer-tax-mltt-rates-and-fees/
+  if (city === "Toronto") {
+    const torontoMLTTBrackets: TaxBracket[] = [
+      { limit: 55000, rate: 0.005 },
+      { limit: 250000, rate: 0.010 },
+      { limit: 400000, rate: 0.015 },
+      { limit: 2000000, rate: 0.020 },
+      { limit: 3000000, rate: 0.025 },
+      { limit: 4000000, rate: 0.044 },
+      { limit: 5000000, rate: 0.0545 },
+      { limit: 10000000, rate: 0.0650 },
+      { limit: 20000000, rate: 0.0755 },
+      { limit: Infinity, rate: 0.0860 },
+    ];
+
+    let provincialTax = calculateMarginalTax(
+      propertyValue,
+      ontarioProvincialBrackets,
+    );
+    let municipalTax = calculateMarginalTax(propertyValue, torontoMLTTBrackets);
+
+    if (firstTimeOwner) {
+      // Provincial FTHB Source: https://www.ontario.ca/document/land-transfer-tax/land-transfer-tax-refunds-first-time-homebuyers
+      // Municipal FTHB Source: https://www.toronto.ca/services-payments/property-taxes-utilities/municipal-land-transfer-tax-mltt/municipal-land-transfer-tax-mltt-rebate-opportunities/
+      const provincialRebate = Math.min(provincialTax, 4000);
+      const municipalRebate = Math.min(municipalTax, 4475);
+      provincialTax -= provincialRebate;
+      municipalTax -= municipalRebate;
+    }
+    return provincialTax + municipalTax;
+  }
+
+  // 3. British Columbia (Vancouver, Victoria)
+  // Tax Source: https://www2.gov.bc.ca/gov/content/taxes/property-taxes/property-transfer-tax
+  if (city === "Vancouver" || city === "Victoria") {
+    const bcBrackets: TaxBracket[] = [
+      { limit: 200000, rate: 0.010 },
+      { limit: 2000000, rate: 0.020 },
+      { limit: Infinity, rate: 0.030 },
+    ];
+
+    let tax = calculateMarginalTax(propertyValue, bcBrackets);
+
+    if (propertyValue > 3000000) {
+      tax += (propertyValue - 3000000) * 0.02; // Luxury Surtax
+    }
+
+    if (firstTimeOwner) {
+      // FTHB Source: https://www2.gov.bc.ca/gov/content/taxes/property-taxes/property-transfer-tax/exemptions/first-time-home-buyers
+      if (propertyValue <= 835000) {
+        tax = 0;
+      } else if (propertyValue < 860000) {
+        // Partial linear phase-out over $25,000 span starting with an $8,000 baseline
+        const exemption = 8000 * ((860000 - propertyValue) / 25000);
+        tax = Math.max(0, tax - exemption);
+      }
+    }
+    return tax;
+  }
+
+  // 4 & 5. Quebec (Montreal, Quebec City)
+  // Tax Sources:
+  // Montreal: https://montreal.ca/en/articles/how-property-transfer-duties-are-calculated-9279
+  // Quebec City: https://www.ville.quebec.qc.ca/citoyens/taxes_evaluation/droits_mutation_immobiliere.aspx
+  if (city === "Montreal" || city === "Quebec") {
+    let tax = 0;
+
+    if (city === "Montreal") {
+      const montrealBrackets: TaxBracket[] = [
+        { limit: 62900, rate: 0.005 },
+        { limit: 315000, rate: 0.010 },
+        { limit: 552300, rate: 0.015 },
+        { limit: 1104700, rate: 0.020 },
+        { limit: 2136500, rate: 0.025 },
+        { limit: 3113000, rate: 0.035 },
+        { limit: Infinity, rate: 0.040 },
+      ];
+      tax = calculateMarginalTax(propertyValue, montrealBrackets);
+    } else {
+      const quebecCityBrackets: TaxBracket[] = [
+        { limit: 62900, rate: 0.005 },
+        { limit: 315000, rate: 0.010 },
+        { limit: 500000, rate: 0.015 },
+        { limit: 750000, rate: 0.025 },
+        { limit: Infinity, rate: 0.030 },
+      ];
+      tax = calculateMarginalTax(propertyValue, quebecCityBrackets);
+    }
+
+    if (firstTimeOwner) {
+      // 2026 Provincial FTHB Source: https://www.cbc.ca/news/canada/montreal/quebec-welcome-tax-homebuyers-1.7168671
+      // Covers first $5,000, plus 25% of remainder up to an additional $875
+      let baseRebate = Math.min(tax, 5000) +
+        Math.min(Math.max(0, tax - 5000) * 0.25, 875);
+
+      // Phase-out between $750,000 and $1,000,000
+      if (propertyValue >= 1000000) {
+        baseRebate = 0;
+      } else if (propertyValue > 750000) {
+        baseRebate *= (1000000 - propertyValue) / 250000;
+      }
+
+      tax = Math.max(0, tax - baseRebate);
+    }
+    return tax;
+  }
+
+  // 6. Manitoba (Winnipeg)
+  // Tax Source: https://www.gov.mb.ca/finance/other/landtransfertax.html
+  // No point-of-sale FTHB land transfer rebate available.
+  if (city === "Winnipeg") {
+    const manitobaBrackets: TaxBracket[] = [
+      { limit: 30000, rate: 0.000 },
+      { limit: 90000, rate: 0.005 },
+      { limit: 150000, rate: 0.010 },
+      { limit: 200000, rate: 0.015 },
+      { limit: Infinity, rate: 0.020 },
+    ];
+    return calculateMarginalTax(propertyValue, manitobaBrackets);
+  }
+
+  // 7. Alberta (Calgary, Edmonton)
+  // Tax Source: https://www.alberta.ca/register-land-title-document-plan
+  // No FTHB rebate available for administrative levies.
+  if (city === "Calgary" || city === "Edmonton") {
+    return 50 + (propertyValue * 0.001);
+  }
+
+  // 8. Saskatchewan (Saskatoon, Regina)
+  // Tax Source: https://www.saskregistries.ca/fees/landtitlesfees
+  // No FTHB rebate available for administrative levies.
+  if (city === "Saskatoon" || city === "Regina") {
+    if (propertyValue <= 500) return 0;
+    if (propertyValue <= 6300) return 25;
+    return propertyValue * 0.004;
+  }
+
+  // 9. Nova Scotia (Halifax)
+  // Tax Source: https://www.halifax.ca/home-property/property-taxes/taxes-halifax
+  // No municipal exemption for DTT.
+  if (city === "Halifax") {
+    return propertyValue * 0.015;
+  }
+
+  // 10. New Brunswick (Fredericton, Moncton, Saint John (NB))
+  // Tax Source: https://laws.gnb.ca/en/document/cs/R-2.1
+  // No FTHB rebate available for RPTT.
+  if (
+    city === "Fredericton" || city === "Moncton" || city === "Saint John (NB)"
+  ) {
+    return propertyValue * 0.010;
+  }
+
+  // 11. Newfoundland and Labrador (Saint John's (NL))
+  // Tax Source: https://www.gov.nl.ca/gs/registries/deeds/deed-reg/
+  if (city === "Saint John's (NL)") {
+    let fee = 100 + (propertyValue * 0.004);
+    if (firstTimeOwner) {
+      // FTHB Source: https://www.nlhc.nl.ca/housing-programs/first-time-homebuyers-program-fhp/
+      // Program covers 50% of legal/registration closing costs
+      fee *= 0.5;
+    }
+    return fee;
+  }
+
+  throw new Error(`Tax calculation logic not implemented for city: ${city}`);
+}

--- a/src/finance/getYahooFinanceData.ts
+++ b/src/finance/getYahooFinanceData.ts
@@ -79,6 +79,15 @@ export default async function getYahooFinanceData(
   } else {
     const response = await fetch(url);
 
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Failed to fetch data: ${response.status} ${response.statusText}${
+          text ? `. ${text}` : ""
+        }`,
+      );
+    }
+
     data = await response.json();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ import type {
   SimParams,
   WinnersColumnar,
 } from "./finance/simulateRentVsBuyMonteCarlo.ts";
-import getLandTransferTax from "./finance/getLandTransferTax.ts";
+import getLandTransferTax, { type City } from "./finance/getLandTransferTax.ts";
 export {
   adjustToInflation,
   decodeMonteCarloMonthlyIterations,
@@ -73,6 +73,7 @@ export {
 
 export type {
   BaseOptions,
+  City,
   ColumnarResult,
   ColumnarReturn,
   MqCategory,

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ import type {
   SimParams,
   WinnersColumnar,
 } from "./finance/simulateRentVsBuyMonteCarlo.ts";
-
+import getLandTransferTax from "./finance/getLandTransferTax.ts";
 export {
   adjustToInflation,
   decodeMonteCarloMonthlyIterations,
@@ -58,6 +58,7 @@ export {
   decodeMonteCarloValues,
   decodeMonteCarloWinners,
   getIncomeTax,
+  getLandTransferTax,
   getMortgagePenalty,
   getRentVsBuyCholeskyMatrix,
   getSalesTax,

--- a/src/web.ts
+++ b/src/web.ts
@@ -42,6 +42,7 @@ import type {
   StochasticData,
   StochasticVariable,
 } from "./finance/helpers/rentVsBuy/getRentVsBuyCholeskyMatrix.ts";
+import getLandTransferTax from "./finance/getLandTransferTax.ts";
 
 export {
   adjustToInflation,
@@ -50,6 +51,7 @@ export {
   decodeMonteCarloValues,
   decodeMonteCarloWinners,
   getIncomeTax,
+  getLandTransferTax,
   getMortgagePenalty,
   getRentVsBuyCholeskyMatrix,
   getSalesTax,

--- a/test/finance/getLandTransferTax.test.ts
+++ b/test/finance/getLandTransferTax.test.ts
@@ -1,0 +1,175 @@
+import { assertEquals, assertThrows } from "jsr:@std/assert";
+import getLandTransferTax from "../../src/finance/getLandTransferTax.ts";
+
+Deno.test("Land Transfer Tax Calculator", async (t) => {
+  await t.step("Ontario Secondary Cities (Provincial Only)", async (st) => {
+    await st.step("Calculates standard tax correctly (Ottawa, $500k)", () => {
+      // 55k * 0.005 + 195k * 0.010 + 150k * 0.015 + 100k * 0.020 = 6475
+      assertEquals(getLandTransferTax("Ottawa", 500000), 6475);
+    });
+
+    await st.step("Applies FTHB rebate correctly (max $4,000 rebate)", () => {
+      // 6475 - 4000 = 2475
+      assertEquals(getLandTransferTax("Ottawa", 500000, true), 2475);
+    });
+
+    await st.step("Caps FTHB rebate at total tax if tax < $4,000", () => {
+      // Tax on $250,000 = 55k * 0.005 + 195k * 0.010 = 2225
+      // 2225 - 2225 (capped rebate) = 0
+      assertEquals(getLandTransferTax("Hamilton", 250000, true), 0);
+    });
+  });
+
+  await t.step("Toronto (Dual Provincial & Municipal Tax)", async (st) => {
+    await st.step("Calculates combined standard tax ($500k)", () => {
+      // Provincial = 6475
+      // Municipal  = 6475
+      assertEquals(getLandTransferTax("Toronto", 500000), 12950);
+    });
+
+    await st.step(
+      "Applies dual FTHB rebates ($4,000 Prov + $4,475 Muni)",
+      () => {
+        // Provincial FTHB = 6475 - 4000 = 2475
+        // Municipal FTHB  = 6475 - 4475 = 2000
+        // Total = 4475
+        assertEquals(getLandTransferTax("Toronto", 500000, true), 4475);
+      },
+    );
+  });
+
+  await t.step("British Columbia (Vancouver / Victoria)", async (st) => {
+    await st.step("Calculates standard tax ($500k)", () => {
+      // 200k * 0.01 + 300k * 0.02 = 8000
+      assertEquals(getLandTransferTax("Vancouver", 500000), 8000);
+    });
+
+    await st.step("Applies absolute FTHB exemption (<= $835k)", () => {
+      assertEquals(getLandTransferTax("Vancouver", 800000, true), 0);
+      assertEquals(getLandTransferTax("Victoria", 835000, true), 0);
+    });
+
+    await st.step("Calculates partial FTHB phase-out ($850k)", () => {
+      // Standard tax on $850k = 200k * 0.01 + 650k * 0.02 = 15000
+      // Phase-out exemption = 8000 * ((860k - 850k) / 25000) = 8000 * (10/25) = 3200
+      // 15000 - 3200 = 11800
+      assertEquals(getLandTransferTax("Vancouver", 850000, true), 11800);
+    });
+
+    await st.step("Applies Luxury Surtax (> $3M)", () => {
+      // Base tax on $3.5M = (200k*0.01) + (1.8M*0.02) + (1.5M*0.03) = 83000
+      // Surtax = 500k * 0.02 = 10000
+      // Total = 93000
+      assertEquals(getLandTransferTax("Vancouver", 3500000), 93000);
+    });
+  });
+
+  await t.step("Quebec (Montreal / Quebec City)", async (st) => {
+    await st.step("Calculates standard tax (Montreal, $500k)", () => {
+      // 62.9k * 0.005 + 252.1k * 0.010 + 185k * 0.015 = 5610.50
+      assertEquals(getLandTransferTax("Montreal", 500000), 5610.5);
+    });
+
+    await st.step("Calculates standard tax (Quebec City, $500k)", () => {
+      // Same brackets as Montreal up to $500k
+      assertEquals(getLandTransferTax("Quebec", 500000), 5610.5);
+    });
+
+    await st.step("Applies FTHB baseline calculation correctly", () => {
+      // Base tax = 5610.50
+      // Rebate = 5000 + min(610.50 * 0.25, 875) = 5000 + 152.625 = 5152.625
+      // Total = 5610.5 - 5152.625 = 457.875
+      assertEquals(getLandTransferTax("Montreal", 500000, true), 457.875);
+    });
+
+    await st.step(
+      "Applies FTHB phase-out multiplier between $750k and $1M",
+      () => {
+        // Tax on $900k = 314.5 + 2521 + (552.3k-315k)*0.015 + (900k-552.3k)*0.02 = 13349
+        // Base Rebate = 5000 + min((13349-5000)*0.25, 875) = 5875
+        // Multiplier = (1000000 - 900000) / 250000 = 0.4
+        // Final Rebate = 5875 * 0.4 = 2350
+        // Total = 13349 - 2350 = 10999
+        assertEquals(getLandTransferTax("Montreal", 900000, true), 10999);
+      },
+    );
+
+    await st.step("Eliminates FTHB rebate entirely at or above $1M", () => {
+      const taxWithoutFTHB = getLandTransferTax("Montreal", 1000000);
+      const taxWithFTHB = getLandTransferTax("Montreal", 1000000, true);
+      assertEquals(taxWithFTHB, taxWithoutFTHB);
+    });
+  });
+
+  await t.step("Manitoba (Winnipeg)", async (st) => {
+    await st.step("Calculates marginal brackets correctly", () => {
+      // 30k*0 + 60k*0.005 + 60k*0.01 + 50k*0.015 + 50k*0.02 = 2650
+      assertEquals(getLandTransferTax("Winnipeg", 250000), 2650);
+    });
+
+    await st.step("Ignores FTHB boolean", () => {
+      assertEquals(getLandTransferTax("Winnipeg", 250000, true), 2650);
+    });
+  });
+
+  await t.step("Alberta (Calgary / Edmonton)", async (st) => {
+    await st.step("Calculates administrative levy correctly", () => {
+      // 50 + 400k * 0.001 = 450
+      assertEquals(getLandTransferTax("Calgary", 400000), 450);
+      assertEquals(getLandTransferTax("Edmonton", 400000), 450);
+    });
+  });
+
+  await t.step("Saskatchewan (Saskatoon / Regina)", async (st) => {
+    await st.step("Returns 0 for value <= 500", () => {
+      assertEquals(getLandTransferTax("Regina", 400), 0);
+    });
+
+    await st.step("Returns flat fee of 25 for value <= 6300", () => {
+      assertEquals(getLandTransferTax("Saskatoon", 6000), 25);
+    });
+
+    await st.step("Calculates ad valorem for > 6300", () => {
+      // 400k * 0.004 = 1600
+      assertEquals(getLandTransferTax("Saskatoon", 400000), 1600);
+    });
+  });
+
+  await t.step("Flat Rate Regions", async (st) => {
+    await st.step("Nova Scotia (Halifax) - 1.5%", () => {
+      assertEquals(getLandTransferTax("Halifax", 400000), 6000);
+      assertEquals(getLandTransferTax("Halifax", 400000, true), 6000);
+    });
+
+    await st.step("New Brunswick - 1.0%", () => {
+      assertEquals(getLandTransferTax("Fredericton", 400000), 4000);
+      assertEquals(getLandTransferTax("Moncton", 400000), 4000);
+      assertEquals(getLandTransferTax("Saint John (NB)", 400000), 4000);
+    });
+  });
+
+  await t.step("Newfoundland and Labrador (Saint John's (NL))", async (st) => {
+    await st.step("Calculates base fee correctly", () => {
+      // 100 + 400k * 0.004 = 1700
+      assertEquals(getLandTransferTax("Saint John's (NL)", 400000), 1700);
+    });
+
+    await st.step("Applies 50% FTHB discount", () => {
+      // 1700 * 0.5 = 850
+      assertEquals(getLandTransferTax("Saint John's (NL)", 400000, true), 850);
+    });
+  });
+
+  await t.step("Error Handling", async (st) => {
+    await st.step("Throws an error for unimplemented or invalid cities", () => {
+      assertThrows(
+        () => {
+          // Type casting bypasses TS, testing runtime resilience
+          getLandTransferTax("Charlottetown" as any, 500000);
+        },
+        Error,
+        "Tax calculation logic not implemented for city: Charlottetown",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #16. Implements Land Transfer Tax calculations for major Canadian cities including progressive brackets and first-time home buyer rebates.