### PR TITLE
Implement adjustToInflation option in Rent vs Buy simulations

### DIFF
--- a/src/finance/helpers/rentVsBuy/toResults.ts
+++ b/src/finance/helpers/rentVsBuy/toResults.ts
@@ -72,8 +72,8 @@ const SALE_NET_GAINS_KEYS = [
 // Fast 2-decimal rounding (mirrors the one in sibling helpers).
 const r2 = (x: number) => Math.round(x * 100) / 100;
 
-function computeTotals(persona: Persona) {
-  const monthlyExpenses = r2(
+function computeTotals(persona: Persona, adj: (x: number) => number) {
+  const monthlyExpenses = adj(
     persona.monthlyExpenses.mortgageCapital +
       persona.monthlyExpenses.mortgageInterests +
       persona.monthlyExpenses.rent +
@@ -89,7 +89,7 @@ function computeTotals(persona: Persona) {
       persona.monthlyExpenses.tfsaFees +
       persona.monthlyExpenses.stocksFees,
   );
-  const cumulativeExpenses = r2(
+  const cumulativeExpenses = adj(
     persona.cumulativeExpenses.rent +
       persona.cumulativeExpenses.insurance +
       persona.cumulativeExpenses.securityDeposit +
@@ -105,34 +105,34 @@ function computeTotals(persona: Persona) {
       persona.cumulativeExpenses.tfsaFees +
       persona.cumulativeExpenses.stocksFees,
   );
-  const monthlyGains = r2(
+  const monthlyGains = adj(
     persona.monthlyGains.tfsaGains +
       persona.monthlyGains.tfsaContribution +
       persona.monthlyGains.stocksGains +
       persona.monthlyGains.newStocks +
       persona.monthlyGains.homeEquityGains,
   );
-  const cumulativeGains = r2(
+  const cumulativeGains = adj(
     persona.cumulativeGains.tfsaGains +
       persona.cumulativeGains.tfsaContribution +
       persona.cumulativeGains.stocksGains +
       persona.cumulativeGains.newStocks +
       persona.cumulativeGains.homeEquityGains,
   );
-  const assets = r2(
+  const assets = adj(
     persona.assets.tfsa +
       persona.assets.stocks +
       persona.assets.securityDeposit +
       persona.assets.homeEquity,
   );
-  const saleCosts = r2(
+  const saleCosts = adj(
     persona.saleCosts.stockTaxes +
       persona.saleCosts.homeSellingCommission +
       persona.saleCosts.homeSellingFixedFees +
       persona.saleCosts.mortgagePenalty +
       persona.saleCosts.mortgageBalance,
   );
-  const saleNetGains = r2(
+  const saleNetGains = adj(
     persona.saleNetGains.stockSellingGains +
       persona.saleNetGains.tfsaSellingGains +
       persona.saleNetGains.homeSellingGains +
@@ -245,6 +245,7 @@ export default function toResults(
   winVariableOnly: boolean,
   mortgagePayment: MortgagePayment | null,
   employmentIncome: number | null,
+  inflationMultiplier: number,
   onRecord?: (
     category: string,
     group: string,
@@ -255,6 +256,8 @@ export default function toResults(
   winVariable?: "balance" | "balanceAfterSelling" | "assets",
   groups?: string[],
 ) {
+  const adj = (x: number) => r2(x * inflationMultiplier);
+
   if (onRecord) {
     // Fast path: stream numeric values directly to the accumulator without
     // allocating result objects. Used by simulateRentVsBuyMonteCarlo when
@@ -268,7 +271,13 @@ export default function toResults(
         const amount = persona.monthlyExpenses[variable];
         totalMonthlyExpenses += amount;
         if (amount !== 0) {
-          onRecord(category, "monthlyExpenses", variable, monthIndex, amount);
+          onRecord(
+            category,
+            "monthlyExpenses",
+            variable,
+            monthIndex,
+            adj(amount),
+          );
         }
       }
       onRecord(
@@ -276,7 +285,7 @@ export default function toResults(
         "totals",
         "monthlyExpenses",
         monthIndex,
-        r2(totalMonthlyExpenses),
+        adj(totalMonthlyExpenses),
       );
     }
 
@@ -291,7 +300,7 @@ export default function toResults(
             "cumulativeExpenses",
             variable,
             monthIndex,
-            amount,
+            adj(amount),
           );
         }
       }
@@ -300,7 +309,7 @@ export default function toResults(
         "totals",
         "cumulativeExpenses",
         monthIndex,
-        r2(totalCumulativeExpenses),
+        adj(totalCumulativeExpenses),
       );
     }
 
@@ -310,7 +319,7 @@ export default function toResults(
         const amount = persona.monthlyGains[variable];
         totalMonthlyGains += amount;
         if (amount !== 0) {
-          onRecord(category, "monthlyGains", variable, monthIndex, amount);
+          onRecord(category, "monthlyGains", variable, monthIndex, adj(amount));
         }
       }
       onRecord(
@@ -318,7 +327,7 @@ export default function toResults(
         "totals",
         "monthlyGains",
         monthIndex,
-        r2(totalMonthlyGains),
+        adj(totalMonthlyGains),
       );
     }
 
@@ -328,7 +337,13 @@ export default function toResults(
         const amount = persona.cumulativeGains[variable];
         totalCumulativeGains += amount;
         if (amount !== 0) {
-          onRecord(category, "cumulativeGains", variable, monthIndex, amount);
+          onRecord(
+            category,
+            "cumulativeGains",
+            variable,
+            monthIndex,
+            adj(amount),
+          );
         }
       }
       onRecord(
@@ -336,7 +351,7 @@ export default function toResults(
         "totals",
         "cumulativeGains",
         monthIndex,
-        r2(totalCumulativeGains),
+        adj(totalCumulativeGains),
       );
     }
 
@@ -346,17 +361,17 @@ export default function toResults(
         const amount = persona.assets[variable];
         totalAssets += amount;
         if (amount !== 0) {
-          onRecord(category, "assets", variable, monthIndex, amount);
+          onRecord(category, "assets", variable, monthIndex, adj(amount));
         }
       }
-      onRecord(category, "totals", "assets", monthIndex, r2(totalAssets));
+      onRecord(category, "totals", "assets", monthIndex, adj(totalAssets));
     }
 
     if (!groups || groups.includes("summary")) {
       for (const variable of SUMMARY_KEYS) {
         const amount = persona.summary[variable];
         if (amount !== 0) {
-          onRecord(category, "summary", variable, monthIndex, amount);
+          onRecord(category, "summary", variable, monthIndex, adj(amount));
         }
       }
     }
@@ -365,7 +380,13 @@ export default function toResults(
       for (const variable of SUMMARY_CUMULATIVE_KEYS) {
         const amount = persona.summaryCumulative[variable];
         if (amount !== 0) {
-          onRecord(category, "summaryCumulative", variable, monthIndex, amount);
+          onRecord(
+            category,
+            "summaryCumulative",
+            variable,
+            monthIndex,
+            adj(amount),
+          );
         }
       }
     }
@@ -376,10 +397,10 @@ export default function toResults(
         const amount = persona.saleCosts[variable];
         totalSaleCosts += amount;
         if (amount !== 0) {
-          onRecord(category, "saleCosts", variable, monthIndex, amount);
+          onRecord(category, "saleCosts", variable, monthIndex, adj(amount));
         }
       }
-      onRecord(category, "totals", "saleCosts", monthIndex, r2(totalSaleCosts));
+      onRecord(category, "totals", "saleCosts", monthIndex, adj(totalSaleCosts));
     }
 
     if (!groups || groups.includes("saleNetGains")) {
@@ -388,7 +409,7 @@ export default function toResults(
         const amount = persona.saleNetGains[variable];
         totalSaleNetGains += amount;
         if (amount !== 0) {
-          onRecord(category, "saleNetGains", variable, monthIndex, amount);
+          onRecord(category, "saleNetGains", variable, monthIndex, adj(amount));
         }
       }
       onRecord(
@@ -396,7 +417,7 @@ export default function toResults(
         "totals",
         "saleNetGains",
         monthIndex,
-        r2(totalSaleNetGains),
+        adj(totalSaleNetGains),
       );
     }
 
@@ -405,7 +426,7 @@ export default function toResults(
     if (monthIndex === numberOfMonths - 1) {
       if (winVariable !== undefined) {
         if (winVariable === "assets") {
-          const totals = computeTotals(persona);
+          const totals = computeTotals(persona, adj);
           results.push({
             monthIndex,
             amount: totals.assets,
@@ -416,7 +437,7 @@ export default function toResults(
         } else {
           results.push({
             monthIndex,
-            amount: persona.summaryCumulative[winVariable],
+            amount: adj(persona.summaryCumulative[winVariable]),
             category,
             group: "summaryCumulative",
             variable: winVariable,
@@ -431,7 +452,7 @@ export default function toResults(
     if (monthIndex === numberOfMonths - 1) {
       if (winVariable !== undefined) {
         if (winVariable === "assets") {
-          const totals = computeTotals(persona);
+          const totals = computeTotals(persona, adj);
           results.push({
             monthIndex,
             amount: totals.assets,
@@ -442,7 +463,7 @@ export default function toResults(
         } else {
           results.push({
             monthIndex,
-            amount: persona.summaryCumulative[winVariable],
+            amount: adj(persona.summaryCumulative[winVariable]),
             category,
             group: "summaryCumulative",
             variable: winVariable,
@@ -453,12 +474,10 @@ export default function toResults(
   } else {
     // Process monthlyExpenses
     if (!groups || groups.includes("monthlyExpenses")) {
-      let totalMonthlyExpenses = 0;
       for (
         const variable of MONTHLY_EXPENSES_KEYS
       ) {
         const amount = persona.monthlyExpenses[variable];
-        totalMonthlyExpenses += amount;
         if (amount !== 0) {
           if (
             (variable === "mortgageCapital" ||
@@ -466,7 +485,7 @@ export default function toResults(
           ) {
             results.push({
               monthIndex,
-              amount,
+              amount: adj(amount),
               category,
               group: "monthlyExpenses",
               variable,
@@ -478,7 +497,7 @@ export default function toResults(
           } else {
             results.push({
               monthIndex,
-              amount,
+              amount: adj(amount),
               category,
               group: "monthlyExpenses",
               variable,
@@ -495,7 +514,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: r2(totalMonthlyExpenses),
+        amount: adj(totalMonthlyExpenses),
         category,
         group: "totals",
         variable: "monthlyExpenses",
@@ -504,16 +523,14 @@ export default function toResults(
 
     // Process cumulativeExpenses
     if (!groups || groups.includes("cumulativeExpenses")) {
-      let totalCumulativeExpenses = 0;
       for (
         const variable of CUMULATIVE_EXPENSES_KEYS
       ) {
         const amount = persona.cumulativeExpenses[variable];
-        totalCumulativeExpenses += amount;
         if (amount !== 0) {
           results.push({
             monthIndex,
-            amount,
+            amount: adj(amount),
             category,
             group: "cumulativeExpenses",
             variable,
@@ -529,7 +546,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: r2(totalCumulativeExpenses),
+        amount: adj(totalCumulativeExpenses),
         category,
         group: "totals",
         variable: "cumulativeExpenses",
@@ -551,16 +568,16 @@ export default function toResults(
           ) {
             results.push({
               monthIndex,
-              amount,
+              amount: adj(amount),
               category,
               group: "monthlyGains",
               variable,
-              homeValue: persona.params.homeValue,
+              homeValue: adj(persona.params.homeValue),
             });
           } else {
             results.push({
               monthIndex,
-              amount,
+              amount: adj(amount),
               category,
               group: "monthlyGains",
               variable,
@@ -576,7 +593,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: r2(totalMonthlyGains),
+        amount: adj(totalMonthlyGains),
         category,
         group: "totals",
         variable: "monthlyGains",
@@ -592,7 +609,7 @@ export default function toResults(
         if (amount !== 0) {
           results.push({
             monthIndex,
-            amount,
+            amount: adj(amount),
             category,
             group: "cumulativeGains",
             variable,
@@ -607,7 +624,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: r2(totalCumulativeGains),
+        amount: adj(totalCumulativeGains),
         category,
         group: "totals",
         variable: "cumulativeGains",
@@ -623,7 +640,7 @@ export default function toResults(
         if (amount !== 0) {
           results.push({
             monthIndex,
-            amount,
+            amount: adj(amount),
             category,
             group: "assets",
             variable,
@@ -638,7 +655,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: r2(totalAssets),
+        amount: adj(totalAssets),
         category,
         group: "totals",
         variable: "assets",
@@ -653,7 +670,7 @@ export default function toResults(
         if (persona.summary[variable] !== 0) {
           results.push({
             monthIndex,
-            amount: persona.summary[variable],
+            amount: adj(persona.summary[variable]),
             category,
             group: "summary",
             variable,
@@ -670,7 +687,7 @@ export default function toResults(
         if (persona.summaryCumulative[variable] !== 0) {
           results.push({
             monthIndex,
-            amount: persona.summaryCumulative[variable],
+            amount: adj(persona.summaryCumulative[variable]),
             category,
             group: "summaryCumulative",
             variable,
@@ -689,16 +706,16 @@ export default function toResults(
           if (variable === "stockTaxes" && employmentIncome !== null) {
             results.push({
               monthIndex,
-              amount,
+              amount: adj(amount),
               category,
               group: "saleCosts",
               variable,
-              employmentIncome,
+              employmentIncome: adj(employmentIncome),
             });
           } else {
             results.push({
               monthIndex,
-              amount,
+              amount: adj(amount),
               category,
               group: "saleCosts",
               variable,
@@ -714,7 +731,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: r2(totalSaleCosts),
+        amount: adj(totalSaleCosts),
         category,
         group: "totals",
         variable: "saleCosts",
@@ -730,7 +747,7 @@ export default function toResults(
         if (amount !== 0) {
           results.push({
             monthIndex,
-            amount,
+            amount: adj(amount),
             category,
             group: "saleNetGains",
             variable,
@@ -745,7 +762,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: r2(totalSaleNetGains),
+        amount: adj(totalSaleNetGains),
         category,
         group: "totals",
         variable: "saleNetGains",

--- a/src/finance/helpers/rentVsBuy/toResults.ts
+++ b/src/finance/helpers/rentVsBuy/toResults.ts
@@ -400,7 +400,13 @@ export default function toResults(
           onRecord(category, "saleCosts", variable, monthIndex, adj(amount));
         }
       }
-      onRecord(category, "totals", "saleCosts", monthIndex, adj(totalSaleCosts));
+      onRecord(
+        category,
+        "totals",
+        "saleCosts",
+        monthIndex,
+        adj(totalSaleCosts),
+      );
     }
 
     if (!groups || groups.includes("saleNetGains")) {

--- a/src/finance/simulateRentVsBuy.ts
+++ b/src/finance/simulateRentVsBuy.ts
@@ -748,8 +748,8 @@ export default function simulateRentVsBuy(
     incrementParameters(monthIndex, buyerVariable, parameters.rates);
 
     if (options.adjustToInflation) {
-      cumulativeInflationFactor *=
-        (1 + parameters.rates[options.adjustToInflation][monthIndex]);
+      cumulativeInflationFactor *= 1 +
+        parameters.rates[options.adjustToInflation][monthIndex];
     }
   }
 

--- a/src/finance/simulateRentVsBuy.ts
+++ b/src/finance/simulateRentVsBuy.ts
@@ -14,6 +14,20 @@ import getLandTransferTax, {
 } from "./getLandTransferTax.ts";
 
 /**
+ * This type defines the keys for the various rates used in the rent vs buy simulation.
+ */
+export type RentVsBuyRates =
+  | "marketReturnRate"
+  | "rentIncrease"
+  | "ownerInsuranceIncrease"
+  | "renterInsuranceIncrease"
+  | "maintenanceIncrease"
+  | "propertyTaxIncrease"
+  | "condoFeeIncrease"
+  | "appreciationIncrease"
+  | "sellingFixedFeesIncrease";
+
+/**
  * Simulates and compares the financial outcomes of renting versus buying a home over a specified number of years.
  * This comprehensive simulation accounts for various factors including mortgage payments (fixed and variable),
  * property taxes, maintenance costs, condo fees, insurance, rent increases, market returns on savings, and
@@ -153,17 +167,6 @@ import getLandTransferTax, {
  * }, { winVariableOnly: true, winVariable: "balanceAfterSelling" });
  * ```
  */
-export type RentVsBuyRates =
-  | "marketReturnRate"
-  | "rentIncrease"
-  | "ownerInsuranceIncrease"
-  | "renterInsuranceIncrease"
-  | "maintenanceIncrease"
-  | "propertyTaxIncrease"
-  | "condoFeeIncrease"
-  | "appreciationIncrease"
-  | "sellingFixedFeesIncrease";
-
 export default function simulateRentVsBuy(
   parameters: {
     startingYear: number;

--- a/src/finance/simulateRentVsBuy.ts
+++ b/src/finance/simulateRentVsBuy.ts
@@ -76,6 +76,7 @@ import getLandTransferTax, {
  *   @param options.winVariable - The variable used to identify the winner when extracting the final record. Use `"balanceAfterSelling"` for net balance after a simulated sale, `"balance"` for cumulative balance, or `"assets"` for total raw assets.
  *   @param options.onRecord - Internal callback used by `simulateRentVsBuyMonteCarlo` when `details.iterations` or `details.quantiles` is enabled. When provided, numeric values are streamed directly to the accumulator instead of being wrapped in result objects, avoiding the per-record heap allocation cost. At the final month, one winner record (the `winVariable` entry) per category is still pushed to the results array for winner extraction.
  *   @param options.groups - Internal filter used by `simulateRentVsBuyMonteCarlo` via `details.iterationsGroups`. Restricts which groups are emitted by `onRecord` and pushed to results.
+ *   @param options.adjustToInflation - The rate parameter used as a proxy for inflation to discount all future dollar values back to Year 0 (today's dollars). For example, setting this to `"sellingFixedFeesIncrease"` will use that parameter's values to calculate the monthly discount factor. Defaults to `undefined` (no adjustment).
  *
  * @returns A detailed array of monthly results for each scenario (renter, buyerFixed, buyerVariable).
  * Each object in the array represents a specific data point for a given month, categorized by:
@@ -152,6 +153,17 @@ import getLandTransferTax, {
  * }, { winVariableOnly: true, winVariable: "balanceAfterSelling" });
  * ```
  */
+export type RentVsBuyRates =
+  | "marketReturnRate"
+  | "rentIncrease"
+  | "ownerInsuranceIncrease"
+  | "renterInsuranceIncrease"
+  | "maintenanceIncrease"
+  | "propertyTaxIncrease"
+  | "condoFeeIncrease"
+  | "appreciationIncrease"
+  | "sellingFixedFeesIncrease";
+
 export default function simulateRentVsBuy(
   parameters: {
     startingYear: number;
@@ -212,6 +224,7 @@ export default function simulateRentVsBuy(
     ) => void;
     winVariable?: "balance" | "balanceAfterSelling" | "assets";
     groups?: string[];
+    adjustToInflation?: RentVsBuyRates;
   } = {},
 ): (
   & {
@@ -476,6 +489,8 @@ export default function simulateRentVsBuy(
 
   const numberOfMonths = parameters.numberOfYears * 12;
 
+  let cumulativeInflationFactor = 1;
+
   // Pre-compute the sales tax multiplier for home selling costs (constant for
   // a given province + year, used inside computeSale every month).
   // Use a large divisor (10000) to avoid toFixed(4) precision loss on rates
@@ -512,6 +527,8 @@ export default function simulateRentVsBuy(
     monthIndex++
   ) {
     const year = parameters.startingYear + Math.floor(monthIndex / 12);
+
+    const inflationMultiplier = 1 / cumulativeInflationFactor;
 
     const currentFixedMortgagePayment = allFixedMortgagePayments[monthIndex];
     const currentVariableMortgagePayment =
@@ -691,6 +708,7 @@ export default function simulateRentVsBuy(
       options.winVariableOnly ?? false,
       null,
       parameters.values.employmentIncome[monthIndex],
+      inflationMultiplier,
       options.onRecord,
       options.winVariable,
       options.groups,
@@ -704,6 +722,7 @@ export default function simulateRentVsBuy(
       options.winVariableOnly ?? false,
       currentFixedMortgagePayment,
       parameters.values.employmentIncome[monthIndex],
+      inflationMultiplier,
       options.onRecord,
       options.winVariable,
       options.groups,
@@ -717,6 +736,7 @@ export default function simulateRentVsBuy(
       options.winVariableOnly ?? false,
       currentVariableMortgagePayment,
       parameters.values.employmentIncome[monthIndex],
+      inflationMultiplier,
       options.onRecord,
       options.winVariable,
       options.groups,
@@ -726,6 +746,11 @@ export default function simulateRentVsBuy(
     incrementParameters(monthIndex, renter, parameters.rates);
     incrementParameters(monthIndex, buyerFixed, parameters.rates);
     incrementParameters(monthIndex, buyerVariable, parameters.rates);
+
+    if (options.adjustToInflation) {
+      cumulativeInflationFactor *=
+        (1 + parameters.rates[options.adjustToInflation][monthIndex]);
+    }
   }
 
   return results;

--- a/src/finance/simulateRentVsBuyMonteCarlo.ts
+++ b/src/finance/simulateRentVsBuyMonteCarlo.ts
@@ -1,5 +1,7 @@
 import { prettyDuration } from "@nshiab/journalism-format";
-import simulateRentVsBuy from "./simulateRentVsBuy.ts";
+import simulateRentVsBuy, {
+  type RentVsBuyRates,
+} from "./simulateRentVsBuy.ts";
 import {
   getCorrelatedShocks,
   stepCir,
@@ -202,6 +204,7 @@ export type BaseOptions = {
     quantiles?: number[];
     iterationsGroups?: MqGroup[];
   };
+  adjustToInflation?: RentVsBuyRates;
 };
 
 /**
@@ -274,6 +277,7 @@ export type BaseOptions = {
  *   @param options.details.iterations - If `true`, captures and returns the raw monthly financial data for every variable, group, and category for each individual iteration. Requires `details.iterationsGroups` to be set and non-empty — throws otherwise. Each record includes `iteration` (0-based index), `category`, `group`, `variable`, `monthIndex`, and `amount`. Useful for custom aggregations or visualization of individual paths. Be aware that this can produce a very large number of records (iterations × months × variables × 3 categories), so use `iterationsGroups` to limit scope.
  *   @param options.details.quantiles - When provided, pre-computes the specified quantile levels (e.g. `[0, 0.5, 1]` for min/median/max) across all iterations for every variable/group/category/month combination. Layout: `data[key][qIdx * cols + monthIndex]`. Decode with `decodeMonteCarloMonthlyQuantiles`.
  *   @param options.details.iterationsGroups - Required when `details.iterations` is `true`. Restricts which groups are included in the `monthlyIterations` output (e.g. `["assets", "summaryCumulative"]`), reducing memory usage. Also filters the shared column-major buffer used by `details.quantiles`.
+ *   @param options.adjustToInflation - The rate parameter used as a proxy for inflation to discount all future dollar values back to Year 0 (today's dollars). For example, setting this to `"sellingFixedFeesIncrease"` will use the simulated path of that parameter to calculate the monthly discount factor. Defaults to `undefined` (no adjustment).
  *
  * @returns An object with all large arrays in columnar format (flat `Float64Array` matrices, transferable via `postMessage`). Use `decodeMonteCarloWinners`, `decodeMonteCarloValues`, `decodeMonteCarloMonthlyIterations`, and `decodeMonteCarloMonthlyQuantiles` from `@nshiab/journalism-finance` to restore object-array shapes.
  *   - `winners`: A `WinnersColumnar` with `monthIndex`, `amount` (`Float64Array`) and `category` (`Uint8Array`) indicating which scenario won each iteration. Decode with `decodeMonteCarloWinners`.
@@ -659,6 +663,7 @@ function simulateRentVsBuyMonteCarlo(
       onRecord,
       winVariable: parameters.winVariable,
       groups: options.details?.iterationsGroups,
+      adjustToInflation: options.adjustToInflation,
     });
 
     // The results array always contains exactly 1 entry per category, pushed in

--- a/src/finance/simulateRentVsBuyMonteCarlo.ts
+++ b/src/finance/simulateRentVsBuyMonteCarlo.ts
@@ -1,7 +1,5 @@
 import { prettyDuration } from "@nshiab/journalism-format";
-import simulateRentVsBuy, {
-  type RentVsBuyRates,
-} from "./simulateRentVsBuy.ts";
+import simulateRentVsBuy, { type RentVsBuyRates } from "./simulateRentVsBuy.ts";
 import {
   getCorrelatedShocks,
   stepCir,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ import mortgageInsurancePremium from "./finance/mortgageInsurancePremium.ts";
 import mortgageMaxAmount from "./finance/mortgageMaxAmount.ts";
 import getYahooFinanceData from "./finance/getYahooFinanceData.ts";
 import variableMortgagePayments from "./finance/variableMortgagePayments.ts";
-import simulateRentVsBuy, { type RentVsBuyRates } from "./finance/simulateRentVsBuy.ts";
+import simulateRentVsBuy, {
+  type RentVsBuyRates,
+} from "./finance/simulateRentVsBuy.ts";
 import simulateRentVsBuyMonteCarlo from "./finance/simulateRentVsBuyMonteCarlo.ts";
 import getRentVsBuyCholeskyMatrix, {
   type StochasticData,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import mortgageInsurancePremium from "./finance/mortgageInsurancePremium.ts";
 import mortgageMaxAmount from "./finance/mortgageMaxAmount.ts";
 import getYahooFinanceData from "./finance/getYahooFinanceData.ts";
 import variableMortgagePayments from "./finance/variableMortgagePayments.ts";
-import simulateRentVsBuy from "./finance/simulateRentVsBuy.ts";
+import simulateRentVsBuy, { type RentVsBuyRates } from "./finance/simulateRentVsBuy.ts";
 import simulateRentVsBuyMonteCarlo from "./finance/simulateRentVsBuyMonteCarlo.ts";
 import getRentVsBuyCholeskyMatrix, {
   type StochasticData,
@@ -79,6 +79,7 @@ export type {
   MqCategory,
   MqGroup,
   MqVariable,
+  RentVsBuyRates,
   SimParams,
   StochasticData,
   StochasticVariable,

--- a/test/finance/simulateRentVsBuy.test.ts
+++ b/test/finance/simulateRentVsBuy.test.ts
@@ -2511,3 +2511,111 @@ Deno.test("simulateRentVsBuy: employmentIncome in results should match the input
     );
   }
 });
+
+Deno.test("simulateRentVsBuy: adjustToInflation should discount future values", () => {
+  const years = 10;
+  const inflationRate = 0.05; // 5% monthly (extreme for testing)
+
+  const rates = {
+    marketReturnRate: new Array(years * 12).fill(0),
+    rentIncrease: new Array(years * 12).fill(inflationRate),
+    ownerInsuranceIncrease: new Array(years * 12).fill(0),
+    renterInsuranceIncrease: new Array(years * 12).fill(0),
+    maintenanceIncrease: new Array(years * 12).fill(0),
+    propertyTaxIncrease: new Array(years * 12).fill(0),
+    condoFeeIncrease: new Array(years * 12).fill(0),
+    appreciationIncrease: new Array(years * 12).fill(0),
+    sellingFixedFeesIncrease: new Array(years * 12).fill(0),
+  };
+
+  const values = {
+    employmentIncome: new Array(years * 12).fill(0),
+    fiveYearInterestRates: new Array(years * 12).fill(0.05),
+    fourYearInterestRates: new Array(years * 12).fill(0.05),
+    threeYearInterestRates: new Array(years * 12).fill(0.05),
+    twoYearInterestRates: new Array(years * 12).fill(0.05),
+    oneYearInterestRates: new Array(years * 12).fill(0.05),
+    variableInterestRates: new Array(years * 12).fill(0.05),
+  };
+
+  const params = {
+    startingYear: 2024,
+    numberOfYears: years,
+    tfsaContributions: false,
+    annualInvestmentFeeRate: 0,
+    couple: false,
+    city: "Toronto" as const,
+    renter: {
+      startingMonthlyRent: 1000,
+      securityDeposit: 0,
+      startingMonthlyInsurance: 0,
+    },
+    buyer: {
+      downPayment: 0,
+      purchasePrice: 0,
+      fixedRateAdjustment: 0,
+      variableRateAdjustment: 0,
+      firstTimeOwner: false,
+      purchaseFixedFees: 0,
+      startingAnnualMaintenanceCost: 0,
+      startingAnnualPropertyTax: 0,
+      startingMonthlyCondoFees: 0,
+      startingMonthlyInsurance: 0,
+      sellingFixedFees: 0,
+      sellingCommissionRate: 0,
+      floorRate: 0,
+    },
+    values,
+    rates,
+  };
+
+  const resultsNormal = simulateRentVsBuy(params);
+  const resultsAdjusted = simulateRentVsBuy(params, {
+    adjustToInflation: "rentIncrease",
+  });
+
+  // Month 0 should be the same
+  const rent0Normal = resultsNormal.find((r) =>
+    r.monthIndex === 0 && r.variable === "rent"
+  )?.amount;
+  const rent0Adjusted = resultsAdjusted.find((r) =>
+    r.monthIndex === 0 && r.variable === "rent"
+  )?.amount;
+  assertEquals(rent0Normal, 1000);
+  assertEquals(rent0Adjusted, 1000);
+
+  // At month 1, rent increased by 5% but is adjusted back
+  // Normal: 1000 * 1.05 = 1050
+  // Adjusted: (1000 * 1.05) / 1.05 = 1000
+  const rent1Normal = resultsNormal.find((r) =>
+    r.monthIndex === 1 && r.variable === "rent"
+  )?.amount;
+  const rent1Adjusted = resultsAdjusted.find((r) =>
+    r.monthIndex === 1 && r.variable === "rent"
+  )?.amount;
+  assertEquals(rent1Normal, 1050);
+  assertEquals(rent1Adjusted, 1000);
+
+  // Check month 12 (1 year later)
+  // Check month 12 (1 year later)
+  const rent12Normal = resultsNormal.find((r) =>
+    r.monthIndex === 12 && r.variable === "rent"
+  )?.amount;
+  const rent12Adjusted = resultsAdjusted.find((r) =>
+    r.monthIndex === 12 && r.variable === "rent"
+  )?.amount;
+  // Let's check they are within 0.1 of 1000 to account for r2 rounding over 12 months.
+  assert(rent12Normal! > 1700);
+  assert(Math.abs(rent12Adjusted! - 1000) < 0.1);
+
+  // Check month 60 (5 years later)
+  const rent60Normal = resultsNormal.find((r) =>
+    r.monthIndex === 60 && r.variable === "rent"
+  )?.amount;
+  const rent60Adjusted = resultsAdjusted.find((r) =>
+    r.monthIndex === 60 && r.variable === "rent"
+  )?.amount;
+  // Let's just assert adjusted is very close to 1000 and nominal is much higher
+  assert(rent60Normal! > 18000);
+  assert(Math.abs(rent60Adjusted! - 1000) < 0.1);
+});

--- a/test/finance/simulateRentVsBuyMonteCarlo.test.ts
+++ b/test/finance/simulateRentVsBuyMonteCarlo.test.ts
@@ -1374,3 +1374,36 @@ Deno.test("simulateRentVsBuyMonteCarlo: executes successfully with a fully corre
 
   assertEquals(results.winners.monthIndex.length, iterations);
 });
+
+Deno.test("simulateRentVsBuyMonteCarlo: adjustToInflation should correctly propagate and discount values", () => {
+  const params = getParamsRentVsBuyMonteCarlo(10, "Montreal", {
+    downPayment: 0.20,
+    purchaseFixedFees: 0.01,
+  }, {
+    renterMonthlyInsurance: 30,
+    ownerMonthlyInsurance: 100,
+    sellingFixedFees: 2000,
+    condoFees: 300,
+  }, false);
+
+  const resultsNormal = simulateRentVsBuyMonteCarlo(params, { verbose: false });
+  const resultsAdjusted = simulateRentVsBuyMonteCarlo(params, {
+    verbose: false,
+    adjustToInflation: "sellingFixedFeesIncrease",
+  });
+
+  // Since sellingFixedFeesIncrease is usually positive (inflation), adjusted amounts should be lower than nominal ones at the end.
+  const avgWinnerAmountNormal =
+    resultsNormal.winners.amount.reduce((a, b) => a + b, 0) / 10;
+  const avgWinnerAmountAdjusted =
+    resultsAdjusted.winners.amount.reduce((a, b) => a + b, 0) / 10;
+
+  console.log(
+    `Average winner amount (normal): ${avgWinnerAmountNormal.toFixed(2)}`,
+  );
+  console.log(
+    `Average winner amount (adjusted): ${avgWinnerAmountAdjusted.toFixed(2)}`,
+  );
+
+  assert(avgWinnerAmountAdjusted < avgWinnerAmountNormal);
+});


### PR DESCRIPTION
This PR adds an `adjustToInflation` option to `simulateRentVsBuy` and `simulateRentVsBuyMonteCarlo`.

### Changes:
- Added `adjustToInflation` parameter to options.
- Refactored `toResults.ts` to handle discounting via a helper function.
- Updated `simulateRentVsBuy` to track cumulative inflation and pass multipliers.
- Propagated option in `simulateRentVsBuyMonteCarlo`.
- Added tests for long-term discounting accuracy.

Fixes #18