### PR TITLE
feat: calculate minimum down payment function

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -369,6 +369,51 @@ function getLandTransferTax(
 
 The total calculated transaction friction cost in Canadian Dollars.
 
+## getMinimumDownPayment
+
+Calculates the minimum down payment required for a property purchase in Canada,
+based on the purchase price.
+
+The calculation follows the Financial Consumer Agency of Canada (FCAC) rules:
+
+- For properties $500,000 or less: 5% of the purchase price.
+- For properties between $500,000 and $1.5 million: 5% of the first $500,000,
+  plus 10% of the portion above $500,000.
+- For properties $1.5 million or more: 20% of the total purchase price.
+
+### Signature
+
+```typescript
+function getMinimumDownPayment(purchasePrice: number): number;
+```
+
+### Parameters
+
+- **`purchasePrice`**: The total price of the property being purchased.
+
+### Returns
+
+The minimum down payment amount.
+
+### Examples
+
+```ts
+// Minimum down payment for a $400,000 home (5%)
+const downPayment400k = getMinimumDownPayment(400_000);
+console.log(downPayment400k); // 20000
+
+// Minimum down payment for a $600,000 home (5% of 500k + 10% of 100k)
+const downPayment600k = getMinimumDownPayment(600_000);
+console.log(downPayment600k); // 35000
+
+// Minimum down payment for a $1,600,000 home (20%)
+const downPayment1600k = getMinimumDownPayment(1_600_000);
+console.log(downPayment1600k); // 320000
+```
+
+Reference:
+https://www.canada.ca/en/financial-consumer-agency/services/mortgages/down-payment.html
+
 ## getMortgagePenalty
 
 Calculates the mortgage prepayment penalty.
@@ -664,9 +709,8 @@ required in such cases.
 
 ### Throws
 
-- **`Error`**: If the down payment is less than 5% of the purchase price, as
-  this is generally the minimum required down payment for insured mortgages in
-  Canada.
+- **`Error`**: If the down payment is less than the minimum required down
+  payment in Canada.
 
 ### Examples
 
@@ -697,7 +741,7 @@ try {
   mortgageInsurancePremium(500_000, 20_000); // 4% down payment
 } catch (error) {
   console.error("Error:", error.message);
-  // Expected output: "Error: The down payment must be more than 5% of the purchase price..."
+  // Expected output: "Error: The down payment is less than the minimum required down payment..."
 }
 ```
 

--- a/src/finance/getMinimumDownPayment.ts
+++ b/src/finance/getMinimumDownPayment.ts
@@ -1,0 +1,38 @@
+/**
+ * Calculates the minimum down payment required for a property purchase in Canada, based on the purchase price.
+ *
+ * The calculation follows the Financial Consumer Agency of Canada (FCAC) rules:
+ * - For properties $500,000 or less: 5% of the purchase price.
+ * - For properties between $500,000 and $1.5 million: 5% of the first $500,000, plus 10% of the portion above $500,000.
+ * - For properties $1.5 million or more: 20% of the total purchase price.
+ *
+ * @param purchasePrice - The total price of the property being purchased.
+ * @returns The minimum down payment amount.
+ *
+ * @example
+ * ```ts
+ * // Minimum down payment for a $400,000 home (5%)
+ * const downPayment400k = getMinimumDownPayment(400_000);
+ * console.log(downPayment400k); // 20000
+ *
+ * // Minimum down payment for a $600,000 home (5% of 500k + 10% of 100k)
+ * const downPayment600k = getMinimumDownPayment(600_000);
+ * console.log(downPayment600k); // 35000
+ *
+ * // Minimum down payment for a $1,600,000 home (20%)
+ * const downPayment1600k = getMinimumDownPayment(1_600_000);
+ * console.log(downPayment1600k); // 320000
+ * ```
+ *
+ * Reference: https://www.canada.ca/en/financial-consumer-agency/services/mortgages/down-payment.html
+ * @category Finance
+ */
+export default function getMinimumDownPayment(purchasePrice: number): number {
+  if (purchasePrice <= 500_000) {
+    return purchasePrice * 0.05;
+  } else if (purchasePrice < 1_500_000) {
+    return 25_000 + (purchasePrice - 500_000) * 0.1;
+  } else {
+    return purchasePrice * 0.2;
+  }
+}

--- a/src/finance/mortgageInsurancePremium.ts
+++ b/src/finance/mortgageInsurancePremium.ts
@@ -1,3 +1,5 @@
+import getMinimumDownPayment from "./getMinimumDownPayment.ts";
+
 /**
  * Calculates the mortgage insurance premium based on the property's purchase price and the down payment amount. This function is designed to reflect the premium rates typically applied in Canada, as outlined by institutions like the Financial Consumer Agency of Canada. The calculated premium is rounded to the nearest integer.
  *
@@ -6,7 +8,7 @@
  * @param purchasePrice - The total price of the property being purchased.
  * @param downPayment - The amount of money paid upfront by the buyer towards the purchase price.
  * @returns The calculated mortgage insurance premium, rounded to the nearest integer. Returns `0` if the down payment is 20% or more, as insurance is typically not required in such cases.
- * @throws {Error} If the down payment is less than 5% of the purchase price, as this is generally the minimum required down payment for insured mortgages in Canada.
+ * @throws {Error} If the down payment is less than the minimum required down payment in Canada.
  *
  * @example
  * ```ts
@@ -36,7 +38,7 @@
  *   mortgageInsurancePremium(500_000, 20_000); // 4% down payment
  * } catch (error) {
  *   console.error("Error:", error.message);
- *   // Expected output: "Error: The down payment must be more than 5% of the purchase price..."
+ *   // Expected output: "Error: The down payment is less than the minimum required down payment..."
  * }
  * ```
  * @category Finance
@@ -46,12 +48,13 @@ export default function mortgageInsurancePremium(
   purchasePrice: number,
   downPayment: number,
 ): number {
+  const downPaymentMin = getMinimumDownPayment(purchasePrice);
   const downPaymentPerc = downPayment / purchasePrice;
   const mortgageAmount = purchasePrice - downPayment;
 
-  if (downPaymentPerc < 0.05) {
+  if (downPayment < downPaymentMin) {
     throw new Error(
-      `The down payment must be more than 5% of the purchase price (downPaymentPerc=${downPaymentPerc}).`,
+      `The down payment is less than the minimum required down payment (${downPayment} < ${downPaymentMin}).`,
     );
   } else if (downPaymentPerc < 0.1) {
     return Math.round(mortgageAmount * 0.04);

--- a/src/finance/mortgageMaxAmount.ts
+++ b/src/finance/mortgageMaxAmount.ts
@@ -1,4 +1,5 @@
 import mortgageInsurancePremium from "./mortgageInsurancePremium.ts";
+import getMinimumDownPayment from "./getMinimumDownPayment.ts";
 
 /**
  * Calculates the maximum affordable property purchase price and the corresponding mortgage amount a borrower can qualify for, based on their annual income, down payment, and current mortgage interest rates. This function is designed to simulate mortgage qualification criteria, taking into account various financial factors and debt service ratios.
@@ -241,21 +242,9 @@ function findMaxAmount(
     purchasePrice += increment
   ) {
     // We check that the down payment is enough
-    if (purchasePrice <= 500_000) {
-      const downPaymentMin = purchasePrice * 0.05;
-      if (downPayment < downPaymentMin) {
-        downPaymentTooLow = true;
-      }
-    } else if (purchasePrice > 500_000 && purchasePrice < 1_500_000) {
-      const downPaymentMin = 25_000 + (purchasePrice - 500_000) * 0.1;
-      if (downPayment < downPaymentMin) {
-        downPaymentTooLow = true;
-      }
-    } else if (purchasePrice >= 1_500_000) {
-      const downPaymentMin = purchasePrice * 0.2;
-      if (downPayment < downPaymentMin) {
-        downPaymentTooLow = true;
-      }
+    const downPaymentMin = getMinimumDownPayment(purchasePrice);
+    if (downPayment < downPaymentMin) {
+      downPaymentTooLow = true;
     }
 
     if (downPaymentTooLow) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import adjustToInflation from "./finance/adjustToInflation.ts";
 import mortgagePayments from "./finance/mortgagePayments.ts";
 import mortgageInsurancePremium from "./finance/mortgageInsurancePremium.ts";
 import mortgageMaxAmount from "./finance/mortgageMaxAmount.ts";
+import getMinimumDownPayment from "./finance/getMinimumDownPayment.ts";
 import getYahooFinanceData from "./finance/getYahooFinanceData.ts";
 import variableMortgagePayments from "./finance/variableMortgagePayments.ts";
 import simulateRentVsBuy, {
@@ -61,6 +62,7 @@ export {
   decodeMonteCarloWinners,
   getIncomeTax,
   getLandTransferTax,
+  getMinimumDownPayment,
   getMortgagePenalty,
   getRentVsBuyCholeskyMatrix,
   getSalesTax,

--- a/test/finance/getMinimumDownPayment.test.ts
+++ b/test/finance/getMinimumDownPayment.test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from "jsr:@std/assert";
+import getMinimumDownPayment from "../../src/finance/getMinimumDownPayment.ts";
+
+Deno.test("should return 5% for purchase price of $400,000", () => {
+  const result = getMinimumDownPayment(400_000);
+  assertEquals(result, 20_000);
+});
+
+Deno.test("should return 5% for purchase price of $500,000", () => {
+  const result = getMinimumDownPayment(500_000);
+  assertEquals(result, 25_000);
+});
+
+Deno.test("should return 5% of 500k + 10% of 100k for purchase price of $600,000", () => {
+  const result = getMinimumDownPayment(600_000);
+  assertEquals(result, 35_000);
+});
+
+Deno.test("should return 5% of 500k + 10% of 999,999 for purchase price of $1,499,999", () => {
+  const result = getMinimumDownPayment(1_499_999);
+  assertEquals(result, 25_000 + 999_999 * 0.1);
+});
+
+Deno.test("should return 20% for purchase price of $1,500,000", () => {
+  const result = getMinimumDownPayment(1_500_000);
+  assertEquals(result, 300_000);
+});
+
+Deno.test("should return 20% for purchase price of $1,600,000", () => {
+  const result = getMinimumDownPayment(1_600_000);
+  assertEquals(result, 320_000);
+});


### PR DESCRIPTION
This PR adds a new `getMinimumDownPayment` function that implements Canadian tiered rules for minimum down payments (00k, 00k–.5M, .5M+).

It also refactors `mortgageInsurancePremium` and `mortgageMaxAmount` to use this central function, ensuring consistency across the library.

Closes #20