### PR TITLE
feat: explicit down payment checks in simulations

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -1205,7 +1205,8 @@ function simulateRentVsBuy(
 - **`parameters.renter.startingMonthlyInsurance`**: The initial monthly renter's
   insurance.
 - **`parameters.buyer`**: Configuration for the buyer scenarios.
-- **`parameters.buyer.downPayment`**: The down payment amount.
+- **`parameters.buyer.downPayment`**: The down payment amount. Must meet the
+  minimum required down payment in Canada based on the purchase price.
 - **`parameters.buyer.purchasePrice`**: The purchase price of the home.
 - **`parameters.buyer.fixedRateAdjustment`**: The adjustment applied to the
   posted fixed mortgage rate (added to the posted rate).
@@ -1292,34 +1293,31 @@ function simulateRentVsBuy(
 ### Returns
 
 A detailed array of monthly results for each scenario (renter, buyerFixed,
-buyerVariable). Each object in the array represents a specific data point for a
-given month, categorized by:
+buyerVariable).
 
-- `monthlyExpenses` or `cumulativeExpenses`:
-- `rent`, `insurance`, `securityDeposit` (for Renter)
-- `mortgageCapital`, `mortgageInterests`, `maintenance`, `propertyTax`,
+### Throws
+
+- **`Error`**: If the down payment is less than the minimum required down
+  payment in Canada. Each object in the array represents a specific data point
+  for a given month, categorized by: - `monthlyExpenses` or
+  `cumulativeExpenses`: - `rent`, `insurance`, `securityDeposit` (for Renter) -
+  `mortgageCapital`, `mortgageInterests`, `maintenance`, `propertyTax`,
   `condoFees`, `downPayment`, `purchaseFixedFees`, `insurancePremium` (for
-  Buyers)
-- `tfsaFees`, `stocksFees` (for all scenarios)
-- `monthlyGains` or `cumulativeGains`:
-- `tfsaGains`, `tfsaContribution`, `stocksGains`, `newStocks` (for all
-  scenarios)
-- `homeEquityGains` (for Buyers)
-- `assets`:
-- `tfsa`, `stocks` (for all scenarios)
-- `securityDeposit` (for Renter)
-- `homeEquity` (for Buyers)
-- `summary`: `balance` (monthly net worth)
-- `summaryCumulative`: `balance` (cumulative net worth), `balanceAfterSelling`
-  (net worth after hypothetical property sale and associated taxes/fees)
-- `saleCosts`: `stockTaxes` (includes `employmentIncome` used for calculation),
+  Buyers) - `tfsaFees`, `stocksFees` (for all scenarios) - `monthlyGains` or
+  `cumulativeGains`: - `tfsaGains`, `tfsaContribution`, `stocksGains`,
+  `newStocks` (for all scenarios) - `homeEquityGains` (for Buyers) - `assets`: -
+  `tfsa`, `stocks` (for all scenarios) - `securityDeposit` (for Renter) -
+  `homeEquity` (for Buyers) - `summary`: `balance` (monthly net worth) -
+  `summaryCumulative`: `balance` (cumulative net worth), `balanceAfterSelling`
+  (net worth after hypothetical property sale and associated taxes/fees) -
+  `saleCosts`: `stockTaxes` (includes `employmentIncome` used for calculation),
   `homeSellingCommission`, `homeSellingFixedFees`, `mortgagePenalty`,
-  `mortgageBalance` (hypothetical costs incurred upon selling)
-- `saleNetGains`: `stockSellingGains`, `tfsaSellingGains`, `homeSellingGains`,
-  `securityDeposit` (hypothetical gains realized upon selling)
-- `totals`: `monthlyExpenses`, `cumulativeExpenses`, `monthlyGains`,
-  `cumulativeGains`, `assets`, `saleCosts`, `saleNetGains` (sum of all variables
-  in each respective group; always emitted even when zero)
+  `mortgageBalance` (hypothetical costs incurred upon selling) - `saleNetGains`:
+  `stockSellingGains`, `tfsaSellingGains`, `homeSellingGains`, `securityDeposit`
+  (hypothetical gains realized upon selling) - `totals`: `monthlyExpenses`,
+  `cumulativeExpenses`, `monthlyGains`, `cumulativeGains`, `assets`,
+  `saleCosts`, `saleNetGains` (sum of all variables in each respective group;
+  always emitted even when zero)
 
 ### Examples
 
@@ -1435,7 +1433,8 @@ function simulateRentVsBuyMonteCarlo(
   month's rent (scenario-dependent).
 - **`parameters.buyer`**: Configuration for the buyer scenarios.
 - **`parameters.buyer.downPayment`**: The total down payment amount paid at the
-  start.
+  start. Must meet the minimum required down payment in Canada based on the
+  initial property appreciation value.
 - **`parameters.buyer.fixedRateAdjustment`**: The adjustment applied to the
   posted fixed mortgage rate (added to the posted rate).
 - **`parameters.buyer.variableRateAdjustment`**: The adjustment applied to the
@@ -1538,17 +1537,19 @@ matrices, transferable via `postMessage`). Use `decodeMonteCarloWinners`,
 `decodeMonteCarloMonthlyQuantiles` from `@nshiab/journalism-finance` to restore
 object-array shapes.
 
-- `winners`: A `WinnersColumnar` with `monthIndex`, `amount` (`Float64Array`)
-  and `category` (`Uint8Array`) indicating which scenario won each iteration.
-  Decode with `decodeMonteCarloWinners`.
-- `values`: A `ColumnarResult` with stochastic path values per iteration
-  (enabled with `options.values`). Decode with `decodeMonteCarloValues`.
-- `details.monthlyIterations`: A `ColumnarResult` with raw monthly records per
+### Throws
+
+- **`Error`**: If the down payment is less than the minimum required down
+  payment in Canada. - `winners`: A `WinnersColumnar` with `monthIndex`,
+  `amount` (`Float64Array`) and `category` (`Uint8Array`) indicating which
+  scenario won each iteration. Decode with `decodeMonteCarloWinners`. -
+  `values`: A `ColumnarResult` with stochastic path values per iteration
+  (enabled with `options.values`). Decode with `decodeMonteCarloValues`. -
+  `details.monthlyIterations`: A `ColumnarResult` with raw monthly records per
   iteration (enabled with `options.details.iterations`). Decode with
-  `decodeMonteCarloMonthlyIterations`.
-- `details.monthlyQuantiles`: A `ColumnarResult` with pre-computed quantile
-  summaries (enabled with `options.details.quantiles`). Decode with
-  `decodeMonteCarloMonthlyQuantiles`.
+  `decodeMonteCarloMonthlyIterations`. - `details.monthlyQuantiles`: A
+  `ColumnarResult` with pre-computed quantile summaries (enabled with
+  `options.details.quantiles`). Decode with `decodeMonteCarloMonthlyQuantiles`.
 
 ### Examples
 

--- a/src/finance/simulateRentVsBuy.ts
+++ b/src/finance/simulateRentVsBuy.ts
@@ -7,6 +7,7 @@ import incrementParameters from "./helpers/rentVsBuy/incrementParameters.ts";
 import precomputeMortgagePayments from "./helpers/rentVsBuy/precomputeMortgagePayments.ts";
 import toResults from "./helpers/rentVsBuy/toResults.ts";
 import mortgageInsurancePremium from "./mortgageInsurancePremium.ts";
+import getMinimumDownPayment from "./getMinimumDownPayment.ts";
 import getSalesTax from "./getSalesTax.ts";
 import getLandTransferTax, {
   type City,
@@ -54,7 +55,7 @@ export type RentVsBuyRates =
  *   @param parameters.renter.securityDeposit - The initial security deposit.
  *   @param parameters.renter.startingMonthlyInsurance - The initial monthly renter's insurance.
  * @param parameters.buyer - Configuration for the buyer scenarios.
- *   @param parameters.buyer.downPayment - The down payment amount.
+ *   @param parameters.buyer.downPayment - The down payment amount. Must meet the minimum required down payment in Canada based on the purchase price.
  *   @param parameters.buyer.purchasePrice - The purchase price of the home.
  *   @param parameters.buyer.fixedRateAdjustment - The adjustment applied to the posted fixed mortgage rate (added to the posted rate).
  *   @param parameters.buyer.variableRateAdjustment - The adjustment applied to the variable mortgage rate (added to the posted rate).
@@ -93,6 +94,7 @@ export type RentVsBuyRates =
  *   @param options.adjustToInflation - The rate parameter used as a proxy for inflation to discount all future dollar values back to Year 0 (today's dollars). For example, setting this to `"sellingFixedFeesIncrease"` will use that parameter's values to calculate the monthly discount factor. Defaults to `undefined` (no adjustment).
  *
  * @returns A detailed array of monthly results for each scenario (renter, buyerFixed, buyerVariable).
+ * @throws {Error} If the down payment is less than the minimum required down payment in Canada.
  * Each object in the array represents a specific data point for a given month, categorized by:
  * - `monthlyExpenses` or `cumulativeExpenses`:
  *   - `rent`, `insurance`, `securityDeposit` (for Renter)
@@ -406,6 +408,13 @@ export default function simulateRentVsBuy(
   }
 
   const province = getProvinceFromCity(parameters.city);
+
+  const downPaymentMin = getMinimumDownPayment(parameters.buyer.purchasePrice);
+  if (parameters.buyer.downPayment < downPaymentMin) {
+    throw new Error(
+      `The down payment is less than the minimum required down payment (${parameters.buyer.downPayment} < ${downPaymentMin}).`,
+    );
+  }
 
   // We keep track of amounts in structured objects
   const renter = getPersona({

--- a/src/finance/simulateRentVsBuyMonteCarlo.ts
+++ b/src/finance/simulateRentVsBuyMonteCarlo.ts
@@ -1,5 +1,6 @@
 import { prettyDuration } from "@nshiab/journalism-format";
 import simulateRentVsBuy, { type RentVsBuyRates } from "./simulateRentVsBuy.ts";
+import getMinimumDownPayment from "./getMinimumDownPayment.ts";
 import {
   getCorrelatedShocks,
   stepCir,
@@ -229,7 +230,7 @@ export type BaseOptions = {
  * @param parameters.renter - Configuration for the renter scenario.
  *   @param parameters.renter.securityDeposit - The initial security deposit or last month's rent (scenario-dependent).
  * @param parameters.buyer - Configuration for the buyer scenarios.
- *   @param parameters.buyer.downPayment - The total down payment amount paid at the start.
+ *   @param parameters.buyer.downPayment - The total down payment amount paid at the start. Must meet the minimum required down payment in Canada based on the initial property appreciation value.
  *   @param parameters.buyer.fixedRateAdjustment - The adjustment applied to the posted fixed mortgage rate (added to the posted rate).
  *   @param parameters.buyer.variableRateAdjustment - The adjustment applied to the variable mortgage rate (added to the posted rate).
  *   @param parameters.buyer.firstTimeOwner - Whether the buyer is a first-time owner, used to calculate land transfer tax rebates.
@@ -278,6 +279,7 @@ export type BaseOptions = {
  *   @param options.adjustToInflation - The rate parameter used as a proxy for inflation to discount all future dollar values back to Year 0 (today's dollars). For example, setting this to `"sellingFixedFeesIncrease"` will use the simulated path of that parameter to calculate the monthly discount factor. Defaults to `undefined` (no adjustment).
  *
  * @returns An object with all large arrays in columnar format (flat `Float64Array` matrices, transferable via `postMessage`). Use `decodeMonteCarloWinners`, `decodeMonteCarloValues`, `decodeMonteCarloMonthlyIterations`, and `decodeMonteCarloMonthlyQuantiles` from `@nshiab/journalism-finance` to restore object-array shapes.
+ * @throws {Error} If the down payment is less than the minimum required down payment in Canada.
  *   - `winners`: A `WinnersColumnar` with `monthIndex`, `amount` (`Float64Array`) and `category` (`Uint8Array`) indicating which scenario won each iteration. Decode with `decodeMonteCarloWinners`.
  *   - `values`: A `ColumnarResult` with stochastic path values per iteration (enabled with `options.values`). Decode with `decodeMonteCarloValues`.
  *   - `details.monthlyIterations`: A `ColumnarResult` with raw monthly records per iteration (enabled with `options.details.iterations`). Decode with `decodeMonteCarloMonthlyIterations`.
@@ -345,6 +347,15 @@ function simulateRentVsBuyMonteCarlo(
   ) {
     throw new Error(
       "simulateRentVsBuyMonteCarlo: details.iterations requires details.iterationsGroups to be set and not empty.",
+    );
+  }
+
+  const downPaymentMin = getMinimumDownPayment(
+    parameters.stochasticParameters.appreciation.initialValue,
+  );
+  if (parameters.buyer.downPayment < downPaymentMin) {
+    throw new Error(
+      `The down payment is less than the minimum required down payment (${parameters.buyer.downPayment} < ${downPaymentMin}).`,
     );
   }
 


### PR DESCRIPTION
Following up on #21, this PR adds explicit fail-fast checks for minimum down payments in `simulateRentVsBuy` and `simulateRentVsBuyMonteCarlo`.

It also updates the JSDoc for these functions to document the regulatory requirement and potential errors.