### PR TITLE
fix: accumulate inflation-adjusted monthly values into cumulatives

### DIFF
--- a/src/finance/helpers/rentVsBuy/computeBalances.ts
+++ b/src/finance/helpers/rentVsBuy/computeBalances.ts
@@ -8,6 +8,7 @@ export default function computeBalances(
   winVariableOnly: boolean,
   monthIndex: number,
   numberOfMonths: number,
+  inflationMultiplier: number,
 ) {
   if (!winVariableOnly || monthIndex === numberOfMonths - 1) {
     // Monthly balance — field names are statically known, avoid Object.keys/reduce
@@ -57,7 +58,7 @@ export default function computeBalances(
       persona.saleNetGains.homeSellingGains +
       persona.saleNetGains.securityDeposit;
     persona.summaryCumulative.balanceAfterSelling = r2(
-      totalSaleNetGains - totalCumulativeExpenses,
+      r2(totalSaleNetGains * inflationMultiplier) - totalCumulativeExpenses,
     );
   }
 }

--- a/src/finance/helpers/rentVsBuy/computeExpenses.ts
+++ b/src/finance/helpers/rentVsBuy/computeExpenses.ts
@@ -8,6 +8,7 @@ export default function computeExpenses(
   monthIndex: number,
   persona: Persona,
   mortgagePayment: MortgagePayment | null,
+  inflationMultiplier: number,
 ) {
   if (mortgagePayment) {
     // Buyer expenses
@@ -20,25 +21,27 @@ export default function computeExpenses(
 
     persona.cumulativeExpenses.mortgageCapital = r2(
       persona.cumulativeExpenses.mortgageCapital +
-        persona.monthlyExpenses.mortgageCapital,
+        persona.monthlyExpenses.mortgageCapital * inflationMultiplier,
     );
     persona.cumulativeExpenses.mortgageInterests = r2(
       persona.cumulativeExpenses.mortgageInterests +
-        persona.monthlyExpenses.mortgageInterests,
+        persona.monthlyExpenses.mortgageInterests * inflationMultiplier,
     );
     persona.cumulativeExpenses.insurance = r2(
-      persona.cumulativeExpenses.insurance + persona.monthlyExpenses.insurance,
+      persona.cumulativeExpenses.insurance +
+        persona.monthlyExpenses.insurance * inflationMultiplier,
     );
     persona.cumulativeExpenses.maintenance = r2(
       persona.cumulativeExpenses.maintenance +
-        persona.monthlyExpenses.maintenance,
+        persona.monthlyExpenses.maintenance * inflationMultiplier,
     );
     persona.cumulativeExpenses.propertyTax = r2(
       persona.cumulativeExpenses.propertyTax +
-        persona.monthlyExpenses.propertyTax,
+        persona.monthlyExpenses.propertyTax * inflationMultiplier,
     );
     persona.cumulativeExpenses.condoFees = r2(
-      persona.cumulativeExpenses.condoFees + persona.monthlyExpenses.condoFees,
+      persona.cumulativeExpenses.condoFees +
+        persona.monthlyExpenses.condoFees * inflationMultiplier,
     );
 
     // Non recurring expenses
@@ -78,10 +81,12 @@ export default function computeExpenses(
     persona.monthlyExpenses.insurance = persona.params.monthlyInsurance;
 
     persona.cumulativeExpenses.rent = r2(
-      persona.cumulativeExpenses.rent + persona.monthlyExpenses.rent,
+      persona.cumulativeExpenses.rent +
+        persona.monthlyExpenses.rent * inflationMultiplier,
     );
     persona.cumulativeExpenses.insurance = r2(
-      persona.cumulativeExpenses.insurance + persona.monthlyExpenses.insurance,
+      persona.cumulativeExpenses.insurance +
+        persona.monthlyExpenses.insurance * inflationMultiplier,
     );
 
     // Non recurring expenses

--- a/src/finance/helpers/rentVsBuy/computeGains.ts
+++ b/src/finance/helpers/rentVsBuy/computeGains.ts
@@ -15,6 +15,7 @@ export default function computeGains(
   tfsaContributions: boolean,
   couple: boolean | undefined,
   annualInvestmentFeeRate: number,
+  inflationMultiplier: number,
 ) {
   // We start by calculating the current month TFSA and stock gains.
   // The effective monthly rate nets out the annual investment fee (e.g. ETF MER).
@@ -43,10 +44,12 @@ export default function computeGains(
     stocksGrossGain - stocksNetGain,
   );
   persona.cumulativeExpenses.tfsaFees = r2(
-    persona.cumulativeExpenses.tfsaFees + persona.monthlyExpenses.tfsaFees,
+    persona.cumulativeExpenses.tfsaFees +
+      persona.monthlyExpenses.tfsaFees * inflationMultiplier,
   );
   persona.cumulativeExpenses.stocksFees = r2(
-    persona.cumulativeExpenses.stocksFees + persona.monthlyExpenses.stocksFees,
+    persona.cumulativeExpenses.stocksFees +
+      persona.monthlyExpenses.stocksFees * inflationMultiplier,
   );
 
   persona.monthlyGains.tfsaGains = tfsaNetGain;
@@ -54,11 +57,11 @@ export default function computeGains(
 
   persona.cumulativeGains.tfsaGains = r2(
     persona.cumulativeGains.tfsaGains +
-      persona.monthlyGains.tfsaGains,
+      persona.monthlyGains.tfsaGains * inflationMultiplier,
   );
   persona.cumulativeGains.stocksGains = r2(
     persona.cumulativeGains.stocksGains +
-      persona.monthlyGains.stocksGains,
+      persona.monthlyGains.stocksGains * inflationMultiplier,
   );
 
   persona.assets.tfsa = r2(
@@ -81,7 +84,7 @@ export default function computeGains(
     );
     persona.cumulativeGains.homeEquityGains = r2(
       persona.cumulativeGains.homeEquityGains +
-        persona.monthlyGains.homeEquityGains,
+        persona.monthlyGains.homeEquityGains * inflationMultiplier,
     );
   }
 
@@ -98,8 +101,8 @@ export default function computeGains(
     let tfsaRoom = getTfsaContribution(
       year,
       couple
-        ? persona.cumulativeGains.tfsaContribution / 2
-        : persona.cumulativeGains.tfsaContribution,
+        ? persona.params.tfsaContributedNominal / 2
+        : persona.params.tfsaContributedNominal,
     );
 
     if (couple) {
@@ -109,8 +112,12 @@ export default function computeGains(
     const tfsaContribution = Math.min(tfsaRoom, monthlySavings);
 
     persona.monthlyGains.tfsaContribution = tfsaContribution;
+    persona.params.tfsaContributedNominal = r2(
+      persona.params.tfsaContributedNominal + tfsaContribution,
+    );
     persona.cumulativeGains.tfsaContribution = r2(
-      persona.cumulativeGains.tfsaContribution + tfsaContribution,
+      persona.cumulativeGains.tfsaContribution +
+        tfsaContribution * inflationMultiplier,
     );
     persona.assets.tfsa = r2(
       persona.assets.tfsa + tfsaContribution,
@@ -126,7 +133,7 @@ export default function computeGains(
   if (monthlySavings > 0) {
     persona.monthlyGains.newStocks = monthlySavings;
     persona.cumulativeGains.newStocks = r2(
-      persona.cumulativeGains.newStocks + monthlySavings,
+      persona.cumulativeGains.newStocks + monthlySavings * inflationMultiplier,
     );
     persona.assets.stocks = r2(
       persona.assets.stocks + monthlySavings,

--- a/src/finance/helpers/rentVsBuy/getPersona.ts
+++ b/src/finance/helpers/rentVsBuy/getPersona.ts
@@ -42,6 +42,7 @@ export default function getPersona(parameters: {
       insurancePremium: parameters.insurancePremium,
       floorRate: parameters.floorRate,
       investsSavings: parameters.investsSavings,
+      tfsaContributedNominal: 0,
     },
     monthlyExpenses: {
       mortgageCapital: 0,

--- a/src/finance/helpers/rentVsBuy/toResults.ts
+++ b/src/finance/helpers/rentVsBuy/toResults.ts
@@ -33,16 +33,6 @@ const CUMULATIVE_EXPENSES_KEYS = [
   "tfsaFees",
   "stocksFees",
 ] as const;
-// One-time upfront costs paid at month 0: their real value equals their nominal
-// value, so they must NOT be multiplied by the inflation discount factor when
-// accumulating in cumulativeExpenses.
-const CUMULATIVE_EXPENSES_ONE_TIME_SET = new Set([
-  "securityDeposit",
-  "downPayment",
-  "purchaseFixedFees",
-  "landTransferTax",
-  "insurancePremium",
-]);
 const MONTHLY_GAINS_KEYS = [
   "tfsaGains",
   "tfsaContribution",

--- a/src/finance/helpers/rentVsBuy/toResults.ts
+++ b/src/finance/helpers/rentVsBuy/toResults.ts
@@ -100,17 +100,15 @@ function computeTotals(persona: Persona, adj: (x: number) => number) {
       persona.monthlyExpenses.stocksFees,
   );
   const cumulativeExpenses = r2(
-    adj(
-      persona.cumulativeExpenses.rent +
-        persona.cumulativeExpenses.insurance +
-        persona.cumulativeExpenses.mortgageCapital +
-        persona.cumulativeExpenses.mortgageInterests +
-        persona.cumulativeExpenses.maintenance +
-        persona.cumulativeExpenses.propertyTax +
-        persona.cumulativeExpenses.condoFees +
-        persona.cumulativeExpenses.tfsaFees +
-        persona.cumulativeExpenses.stocksFees,
-    ) +
+    persona.cumulativeExpenses.rent +
+      persona.cumulativeExpenses.insurance +
+      persona.cumulativeExpenses.mortgageCapital +
+      persona.cumulativeExpenses.mortgageInterests +
+      persona.cumulativeExpenses.maintenance +
+      persona.cumulativeExpenses.propertyTax +
+      persona.cumulativeExpenses.condoFees +
+      persona.cumulativeExpenses.tfsaFees +
+      persona.cumulativeExpenses.stocksFees +
       persona.cumulativeExpenses.securityDeposit +
       persona.cumulativeExpenses.downPayment +
       persona.cumulativeExpenses.purchaseFixedFees +
@@ -124,7 +122,7 @@ function computeTotals(persona: Persona, adj: (x: number) => number) {
       persona.monthlyGains.newStocks +
       persona.monthlyGains.homeEquityGains,
   );
-  const cumulativeGains = adj(
+  const cumulativeGains = r2(
     persona.cumulativeGains.tfsaGains +
       persona.cumulativeGains.tfsaContribution +
       persona.cumulativeGains.stocksGains +
@@ -302,20 +300,17 @@ export default function toResults(
     }
 
     if (!groups || groups.includes("cumulativeExpenses")) {
-      let totalRecurring = 0;
-      let totalOneTime = 0;
+      let totalCumulativeExpenses = 0;
       for (const variable of CUMULATIVE_EXPENSES_KEYS) {
         const amount = persona.cumulativeExpenses[variable];
-        const isOneTime = CUMULATIVE_EXPENSES_ONE_TIME_SET.has(variable);
-        if (isOneTime) totalOneTime += amount;
-        else totalRecurring += amount;
+        totalCumulativeExpenses += amount;
         if (amount !== 0) {
           onRecord(
             category,
             "cumulativeExpenses",
             variable,
             monthIndex,
-            isOneTime ? r2(amount) : adj(amount),
+            r2(amount),
           );
         }
       }
@@ -324,7 +319,7 @@ export default function toResults(
         "totals",
         "cumulativeExpenses",
         monthIndex,
-        r2(adj(totalRecurring) + totalOneTime),
+        r2(totalCumulativeExpenses),
       );
     }
 
@@ -357,7 +352,7 @@ export default function toResults(
             "cumulativeGains",
             variable,
             monthIndex,
-            adj(amount),
+            r2(amount),
           );
         }
       }
@@ -366,7 +361,7 @@ export default function toResults(
         "totals",
         "cumulativeGains",
         monthIndex,
-        adj(totalCumulativeGains),
+        r2(totalCumulativeGains),
       );
     }
 
@@ -400,7 +395,7 @@ export default function toResults(
             "summaryCumulative",
             variable,
             monthIndex,
-            adj(amount),
+            r2(amount),
           );
         }
       }
@@ -458,7 +453,7 @@ export default function toResults(
         } else {
           results.push({
             monthIndex,
-            amount: adj(persona.summaryCumulative[winVariable]),
+            amount: persona.summaryCumulative[winVariable],
             category,
             group: "summaryCumulative",
             variable: winVariable,
@@ -484,7 +479,7 @@ export default function toResults(
         } else {
           results.push({
             monthIndex,
-            amount: adj(persona.summaryCumulative[winVariable]),
+            amount: persona.summaryCumulative[winVariable],
             category,
             group: "summaryCumulative",
             variable: winVariable,
@@ -551,9 +546,7 @@ export default function toResults(
         if (amount !== 0) {
           results.push({
             monthIndex,
-            amount: CUMULATIVE_EXPENSES_ONE_TIME_SET.has(variable)
-              ? r2(amount)
-              : adj(amount),
+            amount: r2(amount),
             category,
             group: "cumulativeExpenses",
             variable,
@@ -563,17 +556,13 @@ export default function toResults(
     }
 
     if (!groups || groups.includes("totals")) {
-      let totalRecurring = 0;
-      let totalOneTime = 0;
+      let totalCumulativeExpenses = 0;
       for (const variable of CUMULATIVE_EXPENSES_KEYS) {
-        const amount = persona.cumulativeExpenses[variable];
-        if (CUMULATIVE_EXPENSES_ONE_TIME_SET.has(variable)) {
-          totalOneTime += amount;
-        } else totalRecurring += amount;
+        totalCumulativeExpenses += persona.cumulativeExpenses[variable];
       }
       results.push({
         monthIndex,
-        amount: r2(adj(totalRecurring) + totalOneTime),
+        amount: r2(totalCumulativeExpenses),
         category,
         group: "totals",
         variable: "cumulativeExpenses",
@@ -636,7 +625,7 @@ export default function toResults(
         if (amount !== 0) {
           results.push({
             monthIndex,
-            amount: adj(amount),
+            amount: r2(amount),
             category,
             group: "cumulativeGains",
             variable,
@@ -651,7 +640,7 @@ export default function toResults(
       }
       results.push({
         monthIndex,
-        amount: adj(totalCumulativeGains),
+        amount: r2(totalCumulativeGains),
         category,
         group: "totals",
         variable: "cumulativeGains",
@@ -714,7 +703,7 @@ export default function toResults(
         if (persona.summaryCumulative[variable] !== 0) {
           results.push({
             monthIndex,
-            amount: adj(persona.summaryCumulative[variable]),
+            amount: r2(persona.summaryCumulative[variable]),
             category,
             group: "summaryCumulative",
             variable,

--- a/src/finance/helpers/rentVsBuy/types/persona.ts
+++ b/src/finance/helpers/rentVsBuy/types/persona.ts
@@ -18,6 +18,7 @@ export type Persona = {
     insurancePremium: number;
     floorRate: number;
     investsSavings: boolean;
+    tfsaContributedNominal: number;
   };
   monthlyExpenses: {
     mortgageCapital: number;

--- a/src/finance/simulateRentVsBuy.ts
+++ b/src/finance/simulateRentVsBuy.ts
@@ -557,13 +557,14 @@ export default function simulateRentVsBuy(
     // We compute the expenses
     const {
       totalMonthlyExpenses: renterTotalMonthlyExpenses,
-    } = computeExpenses(monthIndex, renter, null);
+    } = computeExpenses(monthIndex, renter, null, inflationMultiplier);
     const {
       totalMonthlyExpenses: buyerFixedTotalMonthlyExpenses,
     } = computeExpenses(
       monthIndex,
       buyerFixed,
       currentFixedMortgagePayment,
+      inflationMultiplier,
     );
     const {
       totalMonthlyExpenses: buyerVariableTotalMonthlyExpenses,
@@ -571,6 +572,7 @@ export default function simulateRentVsBuy(
       monthIndex,
       buyerVariable,
       currentVariableMortgagePayment,
+      inflationMultiplier,
     );
 
     // We compute the monthly savings
@@ -591,6 +593,7 @@ export default function simulateRentVsBuy(
       parameters.tfsaContributions,
       parameters.couple,
       parameters.annualInvestmentFeeRate,
+      inflationMultiplier,
     );
     computeGains(
       year,
@@ -602,6 +605,7 @@ export default function simulateRentVsBuy(
       parameters.tfsaContributions,
       parameters.couple,
       parameters.annualInvestmentFeeRate,
+      inflationMultiplier,
     );
     computeGains(
       year,
@@ -613,6 +617,7 @@ export default function simulateRentVsBuy(
       parameters.tfsaContributions,
       parameters.couple,
       parameters.annualInvestmentFeeRate,
+      inflationMultiplier,
     );
 
     // Now we simulate a sale of all assets
@@ -702,18 +707,21 @@ export default function simulateRentVsBuy(
       options.winVariableOnly ?? false,
       monthIndex,
       numberOfMonths,
+      inflationMultiplier,
     );
     computeBalances(
       buyerFixed,
       options.winVariableOnly ?? false,
       monthIndex,
       numberOfMonths,
+      inflationMultiplier,
     );
     computeBalances(
       buyerVariable,
       options.winVariableOnly ?? false,
       monthIndex,
       numberOfMonths,
+      inflationMultiplier,
     );
 
     // We push all results for this month


### PR DESCRIPTION
## Problem

When `adjustToInflation` is set, cumulative expenses and gains were accumulated as raw **nominal** values throughout the simulation. At output time, `toResults.ts` multiplied the entire cumulative sum by the **current month's** inflation discount factor:

```
displayed = Σ(nominal_i) × (1 / cumulativeInflationFactor_T)
```

This incorrectly applies today's deflator uniformly to all past months. A payment made in month 1 gets discounted as heavily as one made in month T — overstating earlier expenses in real terms and giving an incorrect cumulative total.

**Example (2 months, 2% monthly inflation):**
| | Month 1 | Month 2 |
|---|---|---|
| Nominal rent | $1,000 | $1,020 |
| Correct real value | $1,000 / 1.02 = $980 | $1,020 / 1.04 = $981 |
| Correct cumulative real | | **$1,961** |
| Old displayed cumulative | ($1,000 + $1,020) × (1/1.04) = | **$1,942** (wrong) |

## Fix

Multiply each monthly value by `inflationMultiplier` **before** adding it to its cumulative field:

```
cumulativeExpenses.rent += monthly.rent × inflationMultiplier   // real accumulation
```

Each month's contribution is now discounted only by its own factor, giving `Σ(nominal_i × k_i)` instead of `Σ(nominal_i) × k_T`.

## Files changed

- **`computeExpenses.ts`** — add `inflationMultiplier` param; multiply each recurring monthly expense before accumulating. One-time upfront costs are unaffected (multiplier is always 1 at month 0).
- **`computeGains.ts`** — same treatment for `cumulativeGains` and fee fields. TFSA room calculation moved to a new `persona.params.tfsaContributedNominal` tracker (nominal), since `cumulativeGains.tfsaContribution` is now real/deflated and can't be compared against nominal annual limits.
- **`computeBalances.ts`** — `balanceAfterSelling` deflates the point-in-time nominal `saleNetGains` by `inflationMultiplier` before subtracting the already-real `cumulativeExpenses`.
- **`simulateRentVsBuy.ts`** — passes `inflationMultiplier` to all call sites of the three functions above.
- **`toResults.ts`** — removes `adj()` from `cumulativeExpenses`, `cumulativeGains`, and `summaryCumulative` outputs (values are already real). Removes the now-unnecessary one-time/recurring split for cumulative totals. `adj()` is kept for all point-in-time values: `monthlyExpenses`, `monthlyGains`, `assets`, `saleCosts`, `saleNetGains`, `summary.balance`.
- **`types/persona.ts` + `getPersona.ts`** — add `tfsaContributedNominal: number` to `Persona.params`.

## Behaviour when `adjustToInflation` is not set

`inflationMultiplier` is always 1, so all multiplications are no-ops. No change in behaviour.