### PR TITLE
fix: balance and balanceAfterSelling are net of housing costs

### DIFF
--- a/src/finance/helpers/rentVsBuy/computeBalances.ts
+++ b/src/finance/helpers/rentVsBuy/computeBalances.ts
@@ -3,6 +3,28 @@ import type { Persona } from "./types/persona.ts";
 // Fast 2-decimal rounding via pure arithmetic (avoids toFixed string allocations).
 const r2 = (x: number) => Math.round(x * 100) / 100;
 
+/**
+ * Computes monthly and cumulative balance summaries for a persona.
+ *
+ * **`summary.balance`** (monthly): nominal net cash flow for the month —
+ * total gains minus total expenses. Not inflation-adjusted; used as a
+ * point-in-time flow indicator.
+ *
+ * **`summaryCumulative.balance`**: net financial return expressed in today's
+ * dollars — what you currently *have* (assets discounted to today's purchasing
+ * power) minus what housing *cost* you (NPV of all cumulative expenses, each
+ * discounted at its own period's inflation multiplier).
+ * Formula: `adj(totalAssets) - totalCumulativeExpenses`
+ * A positive value means your accumulated wealth exceeds the real cost of
+ * housing; a higher value across scenarios means a better financial outcome.
+ *
+ * **`summaryCumulative.balanceAfterSelling`**: same net-financial-return
+ * concept but uses liquidation proceeds instead of current asset values —
+ * what you would *walk away with* (sale proceeds discounted to today's
+ * dollars, after selling costs, taxes, and mortgage payoff) minus what
+ * housing cost you (same NPV cumulative expenses).
+ * Formula: `adj(totalSaleNetGains) - totalCumulativeExpenses`
+ */
 export default function computeBalances(
   persona: Persona,
   winVariableOnly: boolean,
@@ -11,7 +33,7 @@ export default function computeBalances(
   inflationMultiplier: number,
 ) {
   if (!winVariableOnly || monthIndex === numberOfMonths - 1) {
-    // Monthly balance — field names are statically known, avoid Object.keys/reduce
+    // Monthly balance — nominal net cash flow for the month.
     const totalMonthlyExpenses = persona.monthlyExpenses.mortgageCapital +
       persona.monthlyExpenses.mortgageInterests +
       persona.monthlyExpenses.rent +
@@ -32,7 +54,8 @@ export default function computeBalances(
       totalMonthlyGains - totalMonthlyExpenses,
     );
 
-    // Cumulative balance
+    // Total cumulative expenses (NPV — each month discounted at its own
+    // inflationMultiplier when accumulated in computeExpenses/computeGains).
     const totalCumulativeExpenses = persona.cumulativeExpenses.mortgageCapital +
       persona.cumulativeExpenses.mortgageInterests +
       persona.cumulativeExpenses.rent +
@@ -43,16 +66,22 @@ export default function computeBalances(
       persona.cumulativeExpenses.condoFees +
       persona.cumulativeExpenses.downPayment +
       persona.cumulativeExpenses.purchaseFixedFees +
-      persona.cumulativeExpenses.insurancePremium;
-    const totalCumulativeGains = persona.cumulativeGains.tfsaGains +
-      persona.cumulativeGains.tfsaContribution +
-      persona.cumulativeGains.stocksGains +
-      persona.cumulativeGains.newStocks +
-      persona.cumulativeGains.homeEquityGains;
+      persona.cumulativeExpenses.landTransferTax +
+      persona.cumulativeExpenses.insurancePremium +
+      persona.cumulativeExpenses.tfsaFees +
+      persona.cumulativeExpenses.stocksFees;
+
+    // adj(assets) — current asset value in today's dollars.
+    const totalAssets = persona.assets.tfsa +
+      persona.assets.stocks +
+      persona.assets.securityDeposit +
+      persona.assets.homeEquity;
     persona.summaryCumulative.balance = r2(
-      totalCumulativeGains - totalCumulativeExpenses,
+      r2(totalAssets * inflationMultiplier) - totalCumulativeExpenses,
     );
-    // Balance after selling
+
+    // adj(saleNetGains) — liquidation proceeds in today's dollars (selling
+    // costs, mortgage payoff, and capital gains taxes already deducted).
     const totalSaleNetGains = persona.saleNetGains.stockSellingGains +
       persona.saleNetGains.tfsaSellingGains +
       persona.saleNetGains.homeSellingGains +

--- a/test/finance/simulateRentVsBuy.test.ts
+++ b/test/finance/simulateRentVsBuy.test.ts
@@ -2173,21 +2173,21 @@ Deno.test("should compute the total expenses and savings of a renter and buyer i
       [
         {
           monthIndex: 299,
-          amount: 250130.37,
+          amount: 239494.42,
           category: "renter",
           group: "summaryCumulative",
           variable: "balanceAfterSelling",
         },
         {
           monthIndex: 299,
-          amount: 81350.69,
+          amount: 80016.45,
           category: "buyerFixed",
           group: "summaryCumulative",
           variable: "balanceAfterSelling",
         },
         {
           monthIndex: 299,
-          amount: 131221.91,
+          amount: 129538.75,
           category: "buyerVariable",
           group: "summaryCumulative",
           variable: "balanceAfterSelling",
@@ -2212,21 +2212,21 @@ Deno.test("should compute the total expenses and savings of a renter and buyer i
       [
         {
           monthIndex: 299,
-          amount: 250130.37,
+          amount: 239494.42,
           category: "renter",
           group: "summaryCumulative",
           variable: "balanceAfterSelling",
         },
         {
           monthIndex: 299,
-          amount: 81350.69,
+          amount: 80016.45,
           category: "buyerFixed",
           group: "summaryCumulative",
           variable: "balanceAfterSelling",
         },
         {
           monthIndex: 299,
-          amount: 131221.91,
+          amount: 129538.75,
           category: "buyerVariable",
           group: "summaryCumulative",
           variable: "balanceAfterSelling",


### PR DESCRIPTION
## Summary

Redefines `summaryCumulative.balance` and `summaryCumulative.balanceAfterSelling` to express the net financial return of a housing scenario — what you **have** minus what housing **cost** you.

## New formulas

| Field | Formula | Meaning |
|---|---|---|
| `summaryCumulative.balance` | `adj(assets) − cumulativeExpenses` | Current asset value in today's dollars minus NPV of all housing costs |
| `summaryCumulative.balanceAfterSelling` | `adj(saleNetGains) − cumulativeExpenses` | Liquidation proceeds in today's dollars (after selling fees, mortgage payoff, capital gains tax) minus NPV of all housing costs |

`cumulativeExpenses` uses per-period NPV — each month's payment is discounted at its own `inflationMultiplier` when accumulated — so both sides of the subtraction are in real (today's) dollars.

## Also fixed

- **Omission**: `landTransferTax`, `tfsaFees`, and `stocksFees` were previously missing from `totalCumulativeExpenses` in `computeBalances`. All three are now included.

## Motivation

Previously `balance` was either `adj(assets)` alone (ignoring costs) or a mix of differently-discounted terms. The new formula directly answers: *"after paying all housing costs, how much wealth have you accumulated in today's dollars?"* A higher value means a better financial outcome; comparing across renter/buyerFixed/buyerVariable reveals which scenario leaves you ahead.