### PR TITLE
Fix inflation adjustment and capital gains tax

### DIFF
--- a/src/finance/helpers/rentVsBuy/computeGains.ts
+++ b/src/finance/helpers/rentVsBuy/computeGains.ts
@@ -132,6 +132,9 @@ export default function computeGains(
   );
   if (monthlySavings > 0) {
     persona.monthlyGains.newStocks = monthlySavings;
+    persona.params.stocksContributedNominal = r2(
+      persona.params.stocksContributedNominal + monthlySavings,
+    );
     persona.cumulativeGains.newStocks = r2(
       persona.cumulativeGains.newStocks + monthlySavings * inflationMultiplier,
     );

--- a/src/finance/helpers/rentVsBuy/computeSale.ts
+++ b/src/finance/helpers/rentVsBuy/computeSale.ts
@@ -37,7 +37,7 @@ export default function computeSale(
 
     // First we calculate the sale costs
     const stockGains = persona.assets.stocks -
-      persona.cumulativeGains.newStocks;
+      persona.params.stocksContributedNominal;
 
     // Note: Stock capital gains taxes are calculated using 2025 rates for all simulation years.
     let stockTaxes: number;

--- a/src/finance/helpers/rentVsBuy/getPersona.ts
+++ b/src/finance/helpers/rentVsBuy/getPersona.ts
@@ -43,6 +43,7 @@ export default function getPersona(parameters: {
       floorRate: parameters.floorRate,
       investsSavings: parameters.investsSavings,
       tfsaContributedNominal: 0,
+      stocksContributedNominal: 0,
     },
     monthlyExpenses: {
       mortgageCapital: 0,

--- a/src/finance/helpers/rentVsBuy/types/persona.ts
+++ b/src/finance/helpers/rentVsBuy/types/persona.ts
@@ -19,6 +19,7 @@ export type Persona = {
     floorRate: number;
     investsSavings: boolean;
     tfsaContributedNominal: number;
+    stocksContributedNominal: number;
   };
   monthlyExpenses: {
     mortgageCapital: number;

--- a/src/finance/simulateRentVsBuyMonteCarlo.ts
+++ b/src/finance/simulateRentVsBuyMonteCarlo.ts
@@ -630,10 +630,10 @@ function simulateRentVsBuyMonteCarlo(
       }
     }
 
-    // Dollar-amount GBM paths (0, 2-9) are deflated when adjustToInflation is set.
-    // Rate paths (1 = market returns, 10-15 = interest rates) are never deflated.
+    // Dollar-amount GBM paths (0-9) are deflated when adjustToInflation is set.
+    // Interest rate paths (10-15 = interest rates) are never deflated.
     populateValuesColumnar(i, "employment income", paths[0], true);
-    populateValuesColumnar(i, "market returns", paths[1], false);
+    populateValuesColumnar(i, "market returns", paths[1], true);
     populateValuesColumnar(i, "rent", paths[2], true);
     populateValuesColumnar(i, "owner insurance", paths[3], true);
     populateValuesColumnar(i, "renter insurance", paths[4], true);

--- a/test/finance/simulateRentVsBuyMonteCarlo.test.ts
+++ b/test/finance/simulateRentVsBuyMonteCarlo.test.ts
@@ -1633,7 +1633,45 @@ Deno.test("simulateRentVsBuyMonteCarlo: dollar-amount paths in values should be 
     `Deflated income ${incomeLastAdjusted.value} should be lower than nominal ${incomeLastNormal.value}`,
   );
 
-  // Take the last record of market returns for iteration 0 (a rate, shouldn't be deflated)
+  // Take the last record of rent for iteration 0
+  const rentLastNormal = valsNormal.find(
+    (v) =>
+      v.iteration === 0 && v.variable === "rent" &&
+      v.monthIndex === p.numberOfYears * 12 - 1,
+  );
+  const rentLastAdjusted = valsAdjusted.find(
+    (v) =>
+      v.iteration === 0 && v.variable === "rent" &&
+      v.monthIndex === p.numberOfYears * 12 - 1,
+  );
+
+  assert(rentLastNormal !== undefined);
+  assert(rentLastAdjusted !== undefined);
+  assert(
+    rentLastAdjusted.value < rentLastNormal.value,
+    `Deflated rent ${rentLastAdjusted.value} should be lower than nominal ${rentLastNormal.value}`,
+  );
+
+  // Take the last record of property appreciation for iteration 0
+  const appreciationLastNormal = valsNormal.find(
+    (v) =>
+      v.iteration === 0 && v.variable === "property appreciation" &&
+      v.monthIndex === p.numberOfYears * 12 - 1,
+  );
+  const appreciationLastAdjusted = valsAdjusted.find(
+    (v) =>
+      v.iteration === 0 && v.variable === "property appreciation" &&
+      v.monthIndex === p.numberOfYears * 12 - 1,
+  );
+
+  assert(appreciationLastNormal !== undefined);
+  assert(appreciationLastAdjusted !== undefined);
+  assert(
+    appreciationLastAdjusted.value < appreciationLastNormal.value,
+    `Deflated appreciation ${appreciationLastAdjusted.value} should be lower than nominal ${appreciationLastNormal.value}`,
+  );
+
+  // Take the last record of market returns for iteration 0
   const marketLastNormal = valsNormal.find(
     (v) =>
       v.iteration === 0 && v.variable === "market returns" &&
@@ -1648,10 +1686,8 @@ Deno.test("simulateRentVsBuyMonteCarlo: dollar-amount paths in values should be 
   assert(marketLastNormal !== undefined);
   assert(marketLastAdjusted !== undefined);
 
-  // The rate paths should be exactly equal
-  assertEquals(
-    marketLastAdjusted.value,
-    marketLastNormal.value,
-    "market returns rate should not be deflated",
+  assert(
+    marketLastAdjusted.value < marketLastNormal.value,
+    `Deflated market returns ${marketLastAdjusted.value} should be lower than nominal ${marketLastNormal.value}`,
   );
 });


### PR DESCRIPTION
This PR fixes two issues:
1. In the Monte Carlo simulation, the 'market returns' value path was not being deflated when 'adjustToInflation' was true.
2. In the sale simulation, capital gains taxes were being calculated using a deflated cost basis against a nominal asset value when inflation adjustment was on.

Changes:
- Modified 'Persona' to track 'stocksContributedNominal'.
- Updated 'computeGains' to track nominal contributions.
- Updated 'computeSale' to use nominal cost base for tax calculations.
- Updated 'simulateRentVsBuyMonteCarlo' to deflate 'market returns' index in output.
- Expanded deflation tests in 'simulateRentVsBuyMonteCarlo.test.ts'.